### PR TITLE
feat(phase-3): add web crawling via Crawl4AI

### DIFF
--- a/.planning/IMPROVEMENTS.md
+++ b/.planning/IMPROVEMENTS.md
@@ -2,69 +2,89 @@
 
 PR: https://github.com/sebc-dev/alexandria/pull/9
 Review: 19 fichiers, 45 🟢, 30 🟡, 0 🔴
-Progression: **8/15 complétées**
+Progression: **15/15 complétées**
 
 ---
 
 ## Robustesse production (priorité haute)
 
 - [x] **1. Retry avec backoff sur Crawl4AiClient.crawl()**
-  - Fichiers: `Crawl4AiClient.java`, `application.yml`
-  - Les erreurs transitoires (timeout Chromium) échouent directement
-  - Approche: Spring Retry ou retry manuel avec backoff exponentiel
+  - Fichiers: `Crawl4AiClient.java`, `Crawl4AiConfig.java`, `Crawl4AiProperties.java`, `application.yml`, `build.gradle.kts`, `libs.versions.toml`
+  - Ajouté `spring-retry` + `spring-boot-starter-aop`
+  - `@Retryable` sur `crawl()` (retryFor=RestClientException, config via SpEL expressions)
+  - `@Recover` méthode `recoverCrawl()` pour le fallback gracieux
+  - Config: `alexandria.crawl4ai.retry.{max-attempts,delay-ms,multiplier}` (3, 1000, 2.0)
 
 - [x] **2. Limiter la taille des sitemaps téléchargés**
-  - Fichier: `SitemapParser.java`
-  - `body(byte[].class)` charge tout en RAM, risque OOM sur sitemaps géants
-  - Approche: Limiter la taille du body ou utiliser du streaming
+  - Fichiers: `SitemapParser.java`, `Crawl4AiProperties.java`, `application.yml`
+  - Nouvelle méthode `fetchSitemap()` avec vérification de taille après téléchargement
+  - Limite configurable: `alexandria.crawl4ai.max-sitemap-size-bytes` (défaut 10 Mo)
+  - Log warning et retour null si dépassée
 
 - [x] **3. Singleton Container pattern pour les tests IT**
-  - Fichiers: `Crawl4AiClientIT.java`, `CrawlServiceIT.java`
-  - Deux containers Crawl4AI (~4 Go RAM) démarrés en parallèle
-  - Approche: Créer un `AbstractCrawl4AiIT` ou un singleton container
+  - Fichiers: `SharedCrawl4AiContainer.java` (nouveau), `Crawl4AiClientIT.java`, `CrawlServiceIT.java`
+  - Singleton statique `INSTANCE` avec image centralisée en constante
+  - Méthode `baseUrl()` réutilisée via `@DynamicPropertySource`
+  - Les deux IT partagent un seul container au lieu de deux
 
 ## Qualité de code (priorité moyenne)
 
 - [x] **4. @JsonNaming(SnakeCaseStrategy.class) sur les DTOs Crawl4AI**
-  - Fichiers: `Crawl4AiRequest`, `Crawl4AiMarkdown`, `Crawl4AiPageResult`
-  - Résout le snake_case de manière centralisée au lieu de noms de champs non-Java
+  - Fichiers: `Crawl4AiRequest.java`, `Crawl4AiMarkdown.java`, `Crawl4AiPageResult.java`, `Crawl4AiClient.java`
+  - `browser_config` → `browserConfig`, `crawler_config` → `crawlerConfig`
+  - `raw_markdown` → `rawMarkdown`, `fit_markdown` → `fitMarkdown`, etc.
+  - `status_code` → `statusCode`, `error_message` → `errorMessage`
+  - Supprimé `@JsonIgnoreProperties` inutile sur `Crawl4AiRequest` (cf. #15)
 
 - [x] **5. @ConfigurationProperties record au lieu de @Value**
-  - Fichier: `Crawl4AiConfig.java`
-  - Validation au boot, auto-complétion IDE, `/actuator/configprops`
+  - Fichiers: `Crawl4AiProperties.java` (nouveau), `Crawl4AiConfig.java`
+  - Record `Crawl4AiProperties` avec `@ConfigurationProperties(prefix = "alexandria.crawl4ai")`
+  - Nested record `Retry` pour la config retry
+  - `@EnableConfigurationProperties` sur `Crawl4AiConfig`
 
 - [x] **6. Factoriser normalizeToBase dans UrlNormalizer**
-  - Fichiers: `SitemapParser.java`, `UrlNormalizer.java`
-  - Duplication de logique scheme+host+port
+  - Fichiers: `UrlNormalizer.java`, `SitemapParser.java`
+  - Nouvelle méthode publique `UrlNormalizer.normalizeToBase(String)`
+  - `SitemapParser.normalizeToBase()` supprimée, remplacée par appel à `UrlNormalizer`
+  - `isSameSite()` refactoré pour utiliser `normalizeToBase()`
+  - `effectivePort()` supprimée (devenue inutile)
 
 - [x] **7. Extraire helper extractMarkdown() dans Crawl4AiClient**
   - Fichier: `Crawl4AiClient.java`
-  - Ternaire imbriquée difficile à lire
+  - Ternaire imbriquée extraite en méthode privée `extractMarkdown(Crawl4AiMarkdown)`
+  - Logique claire : null → null, fitMarkdown non-blank → fitMarkdown, sinon rawMarkdown
 
 - [x] **8. Factoriser setup Testcontainers Crawl4AI**
-  - Fichiers: `Crawl4AiClientIT.java`, `CrawlServiceIT.java`
-  - Copié-collé + image `0.8.0` dupliquée à 3 endroits (docker-compose + 2 tests)
+  - Fichiers: `SharedCrawl4AiContainer.java` (nouveau), `Crawl4AiClientIT.java`, `CrawlServiceIT.java`
+  - Combiné avec #3 — image `unclecode/crawl4ai:0.8.0` centralisée en constante `IMAGE`
+  - Config partagée : healthcheck, startup timeout 120s, shmSize 1 Go
 
 ## Complétude (priorité basse)
 
-- [ ] **9. Tri alphabétique des query params dans UrlNormalizer**
+- [x] **9. Tri alphabétique des query params dans UrlNormalizer**
   - Fichier: `UrlNormalizer.java`
-  - `?a=1&b=2` vs `?b=2&a=1` produit deux URLs distinctes
+  - `.sorted()` ajouté dans `filterQueryParams` pour normaliser l'ordre des paramètres
 
-- [ ] **10. Enrichir les tests unitaires UrlNormalizer**
+- [x] **10. Enrichir les tests unitaires UrlNormalizer**
   - Fichier: `UrlNormalizerTest.java`
-  - Manque: port défaut (443→omis), query params mixtes, null/blank, ports différents dans isSameSite
+  - Restructuré en `@Nested` classes (Normalize, NormalizeToBase, IsSameSite)
+  - Ajouté: port défaut omis (80/443), port non-défaut conservé, null/blank, tri alphabétique params, params mixtes tracking+utiles, ports différents dans isSameSite, URL sans schéma, malformed dans normalizeToBase
 
-- [ ] **11. Collecter les pages en échec dans CrawlService**
-  - Fichier: `CrawlService.java`
-  - Retourner `CrawlSiteResult(successPages, failedUrls)` pour le monitoring
+- [x] **11. Collecter les pages en échec dans CrawlService**
+  - Fichiers: `CrawlSiteResult.java` (nouveau), `CrawlService.java`, `CrawlServiceIT.java`
+  - Record `CrawlSiteResult(successPages, failedUrls)` remplace `List<CrawlResult>`
+  - Les échecs (crawl failed + exceptions) sont collectés dans `failedUrls`
 
-- [ ] **12. Crawl concurrent dans CrawlService**
-  - Fichier: `CrawlService.java`
-  - Séquentiel actuellement, lent pour 500+ pages
+- [x] **12. Crawl concurrent dans CrawlService**
+  - Fichiers: `CrawlService.java`, `Crawl4AiProperties.java`, `application.yml`
+  - Crawl par batch avec virtual threads (`Executors.newVirtualThreadPerTaskExecutor()`)
+  - Concurrence configurable: `alexandria.crawl4ai.crawl-concurrency` (défaut 4)
+  - Compatible BFS link-crawl (URLs découverts ajoutés entre les batchs)
 
 ## Cosmétique (nice to have)
 
-- [ ] **13. Regrouper dépendances par domaine dans build.gradle.kts**
-- [ ] **14. Port Crawl4AI optionnel dans docker-compose.yml pour debug local**
-- [ ] **15. Retirer @JsonIgnoreProperties de Crawl4AiRequest** (inutile sur un objet sérialisé)
+- [x] **13. Regrouper dépendances par domaine dans build.gradle.kts**
+  - Sections: Spring Boot, AI/Embeddings, Web Crawling, Database, Testing
+- [x] **14. Port Crawl4AI optionnel dans docker-compose.yml pour debug local**
+  - Port 11235 commenté avec instruction pour activer
+- [x] **15. Retirer @JsonIgnoreProperties de Crawl4AiRequest** (fait avec #4 — remplacé par `@JsonNaming`)

--- a/.planning/IMPROVEMENTS.md
+++ b/.planning/IMPROVEMENTS.md
@@ -1,0 +1,70 @@
+# Améliorations post-review — phase-3/web-crawling
+
+PR: https://github.com/sebc-dev/alexandria/pull/9
+Review: 19 fichiers, 45 🟢, 30 🟡, 0 🔴
+Progression: **8/15 complétées**
+
+---
+
+## Robustesse production (priorité haute)
+
+- [x] **1. Retry avec backoff sur Crawl4AiClient.crawl()**
+  - Fichiers: `Crawl4AiClient.java`, `application.yml`
+  - Les erreurs transitoires (timeout Chromium) échouent directement
+  - Approche: Spring Retry ou retry manuel avec backoff exponentiel
+
+- [x] **2. Limiter la taille des sitemaps téléchargés**
+  - Fichier: `SitemapParser.java`
+  - `body(byte[].class)` charge tout en RAM, risque OOM sur sitemaps géants
+  - Approche: Limiter la taille du body ou utiliser du streaming
+
+- [x] **3. Singleton Container pattern pour les tests IT**
+  - Fichiers: `Crawl4AiClientIT.java`, `CrawlServiceIT.java`
+  - Deux containers Crawl4AI (~4 Go RAM) démarrés en parallèle
+  - Approche: Créer un `AbstractCrawl4AiIT` ou un singleton container
+
+## Qualité de code (priorité moyenne)
+
+- [x] **4. @JsonNaming(SnakeCaseStrategy.class) sur les DTOs Crawl4AI**
+  - Fichiers: `Crawl4AiRequest`, `Crawl4AiMarkdown`, `Crawl4AiPageResult`
+  - Résout le snake_case de manière centralisée au lieu de noms de champs non-Java
+
+- [x] **5. @ConfigurationProperties record au lieu de @Value**
+  - Fichier: `Crawl4AiConfig.java`
+  - Validation au boot, auto-complétion IDE, `/actuator/configprops`
+
+- [x] **6. Factoriser normalizeToBase dans UrlNormalizer**
+  - Fichiers: `SitemapParser.java`, `UrlNormalizer.java`
+  - Duplication de logique scheme+host+port
+
+- [x] **7. Extraire helper extractMarkdown() dans Crawl4AiClient**
+  - Fichier: `Crawl4AiClient.java`
+  - Ternaire imbriquée difficile à lire
+
+- [x] **8. Factoriser setup Testcontainers Crawl4AI**
+  - Fichiers: `Crawl4AiClientIT.java`, `CrawlServiceIT.java`
+  - Copié-collé + image `0.8.0` dupliquée à 3 endroits (docker-compose + 2 tests)
+
+## Complétude (priorité basse)
+
+- [ ] **9. Tri alphabétique des query params dans UrlNormalizer**
+  - Fichier: `UrlNormalizer.java`
+  - `?a=1&b=2` vs `?b=2&a=1` produit deux URLs distinctes
+
+- [ ] **10. Enrichir les tests unitaires UrlNormalizer**
+  - Fichier: `UrlNormalizerTest.java`
+  - Manque: port défaut (443→omis), query params mixtes, null/blank, ports différents dans isSameSite
+
+- [ ] **11. Collecter les pages en échec dans CrawlService**
+  - Fichier: `CrawlService.java`
+  - Retourner `CrawlSiteResult(successPages, failedUrls)` pour le monitoring
+
+- [ ] **12. Crawl concurrent dans CrawlService**
+  - Fichier: `CrawlService.java`
+  - Séquentiel actuellement, lent pour 500+ pages
+
+## Cosmétique (nice to have)
+
+- [ ] **13. Regrouper dépendances par domaine dans build.gradle.kts**
+- [ ] **14. Port Crawl4AI optionnel dans docker-compose.yml pour debug local**
+- [ ] **15. Retirer @JsonIgnoreProperties de Crawl4AiRequest** (inutile sur un objet sérialisé)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -15,7 +15,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [ ] **Phase 0: CI & Quality Gate** - Local and GitHub CI with unit tests, integration tests, mutation testing, dead code detection, and architecture tests
 - [ ] **Phase 1: Foundation & Infrastructure** - PostgreSQL+pgvector schema, Spring Boot skeleton, ONNX embeddings, Docker Compose
 - [x] **Phase 2: Core Search** - Hybrid search (vector + keyword + RRF) verifiable with test data
-- [ ] **Phase 3: Web Crawling** - Crawl4AI sidecar integration for recursive JS-capable crawling
+- [x] **Phase 3: Web Crawling** - Crawl4AI sidecar integration for recursive JS-capable crawling
 - [ ] **Phase 4: Ingestion Pipeline** - Markdown-aware chunking, metadata enrichment, code extraction
 - [ ] **Phase 5: MCP Server** - stdio transport exposing search and management tools to Claude Code
 - [ ] **Phase 6: Source Management** - CRUD operations for documentation sources with status tracking
@@ -86,8 +86,8 @@ Plans:
 **Plans:** 2 plans
 
 Plans:
-- [ ] 03-01-PLAN.md -- Crawl4AI REST client, Spring RestClient config, request/response DTOs, Docker Compose shm_size fix, integration test
-- [ ] 03-02-PLAN.md -- SitemapParser, UrlNormalizer, PageDiscoveryService, CrawlService orchestrator, integration test
+- [x] 03-01-PLAN.md -- Crawl4AI REST client, Spring RestClient config, request/response DTOs, Docker Compose shm_size fix, integration test
+- [x] 03-02-PLAN.md -- SitemapParser, UrlNormalizer, PageDiscoveryService, CrawlService orchestrator, integration test
 
 ### Phase 4: Ingestion Pipeline
 **Goal**: Crawled Markdown is transformed into richly-annotated, searchable chunks that preserve code block integrity and heading hierarchy -- the quality-critical transformation layer
@@ -183,7 +183,7 @@ Note: Phases 2 and 3 can execute in parallel (both depend only on Phase 1).
 | 0. CI & Quality Gate | 0/2 | Planned | - |
 | 1. Foundation & Infrastructure | 0/2 | Planned | - |
 | 2. Core Search | 2/2 | ✓ Complete | 2026-02-15 |
-| 3. Web Crawling | 0/TBD | Not started | - |
+| 3. Web Crawling | 2/2 | ✓ Complete | 2026-02-15 |
 | 4. Ingestion Pipeline | 0/TBD | Not started | - |
 | 5. MCP Server | 0/TBD | Not started | - |
 | 6. Source Management | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,23 +5,23 @@
 See: .planning/PROJECT.md (updated 2026-02-14)
 
 **Core value:** Claude Code peut trouver et retourner des extraits de documentation technique pertinents et precis pour n'importe quel framework ou librairie indexe, a la demande.
-**Current focus:** Phase 3 - Web Crawling
+**Current focus:** Phase 3 - Web Crawling (complete)
 
 ## Current Position
 
 Phase: 3 of 9 (Web Crawling)
-Plan: 1 of 2 in current phase (03-01 complete)
-Status: Plan 03-01 complete, ready for 03-02
-Last activity: 2026-02-15 -- Completed 03-01-PLAN.md (Crawl4AI REST client, DTOs, integration tests)
+Plan: 2 of 2 complete in Phase 03 (03-01, 03-02 complete)
+Status: Phase 03 complete
+Last activity: 2026-02-15 -- Completed 03-02-PLAN.md (page discovery, crawl orchestration)
 
 Progress: [███░░░░░░░] 30%
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 5
-- Average duration: 4.2min
-- Total execution time: 0.35 hours
+- Total plans completed: 7
+- Average duration: 4.3min
+- Total execution time: 0.50 hours
 
 **By Phase:**
 
@@ -29,10 +29,10 @@ Progress: [███░░░░░░░] 30%
 |-------|-------|-------|----------|
 | 00-ci-quality-gate | 2 | 11min | 5.5min |
 | 01-foundation-infrastructure | 2 | 7min | 3.5min |
-| 03-web-crawling | 1 | 4min | 4min |
+| 03-web-crawling | 2 | 9min | 4.5min |
 
 **Recent Trend:**
-- Last 5 plans: 7min, 4min, 3min, 4min, 4min
+- Last 5 plans: 3min, 4min, 4min, 4min, 5min
 - Trend: stable
 
 *Updated after each plan completion*
@@ -72,6 +72,9 @@ Recent decisions affecting current work:
 - [03-01]: Catch RestClientException in Crawl4AiClient for graceful failure handling (Crawl4AI returns HTTP 500 for unreachable URLs)
 - [03-01]: Made BaseIntegrationTest public for cross-package extension from crawl test package
 - [03-01]: PruningContentFilter threshold 0.48 with min_word_threshold 20 for documentation content density
+- [03-02]: UrlNormalizer as static utility (no Spring bean) since it has no dependencies
+- [03-02]: CrawlService follows links only in LINK_CRAWL mode; trusts sitemap URL list when available
+- [03-02]: Sequential page crawling (no concurrency) to keep Crawl4AI sidecar stable
 
 ### Pending Todos
 
@@ -90,6 +93,6 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-15
-Stopped at: Completed 03-01-PLAN.md (Crawl4AI REST client, DTOs, integration tests)
+Stopped at: Completed 03-02-PLAN.md (page discovery, crawl orchestration)
 Resume file: None
-Next: Phase 03 Plan 02 (page discovery and orchestration)
+Next: Phase 02 (parallel eligible) -- Phase 03 complete

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -12,16 +12,16 @@ See: .planning/PROJECT.md (updated 2026-02-14)
 Phase: 3 of 9 (Web Crawling)
 Plan: 2 of 2 complete in Phase 03 (03-01, 03-02 complete)
 Status: Phase 03 complete
-Last activity: 2026-02-15 -- Completed 03-02-PLAN.md (page discovery, crawl orchestration)
+Last activity: 2026-02-15 -- Completed phase 03 verification
 
 Progress: [███░░░░░░░] 30%
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 7
-- Average duration: 4.3min
-- Total execution time: 0.50 hours
+- Total plans completed: 8
+- Average duration: 4.4min
+- Total execution time: 0.58 hours
 
 **By Phase:**
 
@@ -32,7 +32,7 @@ Progress: [███░░░░░░░] 30%
 | 03-web-crawling | 2 | 9min | 4.5min |
 
 **Recent Trend:**
-- Last 5 plans: 3min, 4min, 4min, 4min, 5min
+- Last 5 plans: 4min, 4min, 4min, 5min, 5min
 - Trend: stable
 
 *Updated after each plan completion*
@@ -93,6 +93,6 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-15
-Stopped at: Completed 03-02-PLAN.md (page discovery, crawl orchestration)
+Stopped at: Completed phase 03 verification -- web crawling verified
 Resume file: None
 Next: Phase 02 (parallel eligible) -- Phase 03 complete

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,14 +5,14 @@
 See: .planning/PROJECT.md (updated 2026-02-14)
 
 **Core value:** Claude Code peut trouver et retourner des extraits de documentation technique pertinents et precis pour n'importe quel framework ou librairie indexe, a la demande.
-**Current focus:** Phase 2 - Core Search
+**Current focus:** Phase 3 - Web Crawling
 
 ## Current Position
 
-Phase: 2 of 9 (Core Search)
-Plan: 1 of 2 complete in Phase 02 (02-01 complete)
-Status: 02-01 complete, ready for 02-02
-Last activity: 2026-02-15 -- Completed 02-01-PLAN.md (hybrid search infrastructure, SearchService, domain DTOs)
+Phase: 3 of 9 (Web Crawling)
+Plan: 1 of 2 in current phase (03-01 complete)
+Status: Plan 03-01 complete, ready for 03-02
+Last activity: 2026-02-15 -- Completed 03-01-PLAN.md (Crawl4AI REST client, DTOs, integration tests)
 
 Progress: [███░░░░░░░] 30%
 
@@ -20,8 +20,8 @@ Progress: [███░░░░░░░] 30%
 
 **Velocity:**
 - Total plans completed: 5
-- Average duration: 4.3min
-- Total execution time: 0.36 hours
+- Average duration: 4.2min
+- Total execution time: 0.35 hours
 
 **By Phase:**
 
@@ -29,10 +29,10 @@ Progress: [███░░░░░░░] 30%
 |-------|-------|-------|----------|
 | 00-ci-quality-gate | 2 | 11min | 5.5min |
 | 01-foundation-infrastructure | 2 | 7min | 3.5min |
-| 02-core-search | 1 | 4min | 4min |
+| 03-web-crawling | 1 | 4min | 4min |
 
 **Recent Trend:**
-- Last 5 plans: 4min, 3min, 4min, 4min
+- Last 5 plans: 7min, 4min, 3min, 4min, 4min
 - Trend: stable
 
 *Updated after each plan completion*
@@ -69,6 +69,9 @@ Recent decisions affecting current work:
 - [02-01]: SearchMode is nested enum PgVectorEmbeddingStore.SearchMode, not top-level class (research doc was incorrect)
 - [02-01]: Metadata keys use snake_case convention: source_url, section_path -- must match ingestion-time keys
 - [02-01]: RRF k=60 (standard default from original RRF paper) for v1, tunable in Phase 8
+- [03-01]: Catch RestClientException in Crawl4AiClient for graceful failure handling (Crawl4AI returns HTTP 500 for unreachable URLs)
+- [03-01]: Made BaseIntegrationTest public for cross-package extension from crawl test package
+- [03-01]: PruningContentFilter threshold 0.48 with min_word_threshold 20 for documentation content density
 
 ### Pending Todos
 
@@ -87,6 +90,6 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-15
-Stopped at: Completed 02-01-PLAN.md (hybrid search infrastructure, SearchService, domain DTOs)
+Stopped at: Completed 03-01-PLAN.md (Crawl4AI REST client, DTOs, integration tests)
 Resume file: None
-Next: Phase 02 Plan 02 (search integration tests)
+Next: Phase 03 Plan 02 (page discovery and orchestration)

--- a/.planning/phases/03-web-crawling/03-01-SUMMARY.md
+++ b/.planning/phases/03-web-crawling/03-01-SUMMARY.md
@@ -1,0 +1,147 @@
+---
+phase: 03-web-crawling
+plan: 01
+subsystem: crawl
+tags: [crawl4ai, restclient, docker, testcontainers, markdown, web-crawling]
+
+# Dependency graph
+requires:
+  - phase: 01-foundation-infrastructure
+    provides: Spring Boot app with Docker Compose, Testcontainers base, application.yml structure
+provides:
+  - Crawl4AiClient bean for single-page crawling via Crawl4AI REST API
+  - Request/response DTOs matching Crawl4AI JSON schema
+  - CrawlResult domain DTO (url, markdown, internalLinks, success, errorMessage)
+  - RestClient bean with configurable base-url/timeouts for Crawl4AI sidecar
+  - Docker Compose crawl4ai service with shm_size fix
+  - crawler-commons dependency for future sitemap parsing
+affects: [03-02-web-crawling, 04-markdown-chunking]
+
+# Tech tracking
+tech-stack:
+  added: [crawler-commons 1.6]
+  patterns: [Crawl4AI REST client via Spring RestClient, PruningContentFilter for boilerplate removal, type/params JSON serialization for Crawl4AI config]
+
+key-files:
+  created:
+    - src/main/java/dev/alexandria/crawl/Crawl4AiClient.java
+    - src/main/java/dev/alexandria/crawl/Crawl4AiConfig.java
+    - src/main/java/dev/alexandria/crawl/Crawl4AiRequest.java
+    - src/main/java/dev/alexandria/crawl/Crawl4AiResponse.java
+    - src/main/java/dev/alexandria/crawl/Crawl4AiPageResult.java
+    - src/main/java/dev/alexandria/crawl/Crawl4AiMarkdown.java
+    - src/main/java/dev/alexandria/crawl/Crawl4AiLink.java
+    - src/main/java/dev/alexandria/crawl/CrawlResult.java
+    - src/integrationTest/java/dev/alexandria/crawl/Crawl4AiClientIT.java
+  modified:
+    - gradle/libs.versions.toml
+    - build.gradle.kts
+    - src/main/resources/application.yml
+    - docker-compose.yml
+    - src/integrationTest/java/dev/alexandria/BaseIntegrationTest.java
+
+key-decisions:
+  - "Catch RestClientException in Crawl4AiClient to return CrawlResult(success=false) instead of propagating HTTP 500 errors"
+  - "Made BaseIntegrationTest public to allow cross-package extension from dev.alexandria.crawl"
+  - "PruningContentFilter threshold 0.48 with min_word_threshold 20 for documentation content density"
+
+patterns-established:
+  - "Crawl4AI type/params JSON format: nested {type, params} objects for BrowserConfig, CrawlerRunConfig, content filters"
+  - "Prefer fit_markdown (boilerplate-removed) over raw_markdown with fallback"
+  - "GenericContainer with withCreateContainerCmdModifier for shm_size in Testcontainers"
+
+# Metrics
+duration: 4min
+completed: 2026-02-15
+---
+
+# Phase 3 Plan 1: Crawl4AI REST Client Summary
+
+**Spring RestClient integration with Crawl4AI sidecar for single-page crawling, PruningContentFilter boilerplate removal, and real-container integration tests**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-02-15T10:34:11Z
+- **Completed:** 2026-02-15T10:38:41Z
+- **Tasks:** 2
+- **Files modified:** 14
+
+## Accomplishments
+- Crawl4AiClient bean crawls a single URL via Crawl4AI POST /crawl and returns clean Markdown with internal links
+- PruningContentFilter configured for boilerplate removal (nav, footer, header stripping)
+- Docker Compose crawl4ai service fixed with shm_size: 1g to prevent Chromium crashes
+- Integration test proves end-to-end crawl against real Crawl4AI container (3 tests passing)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Crawl4AI dependency, config properties, RestClient bean, and DTOs** - `d186473` (feat)
+2. **Task 2: Crawl4AiClient service and integration test** - `5a4c7ee` (feat)
+
+## Files Created/Modified
+- `src/main/java/dev/alexandria/crawl/Crawl4AiClient.java` - Service wrapping RestClient for Crawl4AI POST /crawl with error handling
+- `src/main/java/dev/alexandria/crawl/Crawl4AiConfig.java` - RestClient bean with configurable base URL and timeouts
+- `src/main/java/dev/alexandria/crawl/Crawl4AiRequest.java` - Request DTO with urls, browser_config, crawler_config
+- `src/main/java/dev/alexandria/crawl/Crawl4AiResponse.java` - Response DTO wrapping success flag and page results
+- `src/main/java/dev/alexandria/crawl/Crawl4AiPageResult.java` - Per-page result with markdown, links, convenience internalLinkHrefs()
+- `src/main/java/dev/alexandria/crawl/Crawl4AiMarkdown.java` - Markdown DTO: raw_markdown, fit_markdown, citations, references
+- `src/main/java/dev/alexandria/crawl/Crawl4AiLink.java` - Link DTO: href, text, title
+- `src/main/java/dev/alexandria/crawl/CrawlResult.java` - Domain DTO: url, markdown, internalLinks, success, errorMessage
+- `src/integrationTest/java/dev/alexandria/crawl/Crawl4AiClientIT.java` - 3 integration tests with real Crawl4AI container
+- `gradle/libs.versions.toml` - Added crawler-commons 1.6
+- `build.gradle.kts` - Added crawler-commons dependency
+- `src/main/resources/application.yml` - Added alexandria.crawl4ai config properties
+- `docker-compose.yml` - Added shm_size: 1g and memory limits to crawl4ai service
+- `src/integrationTest/java/dev/alexandria/BaseIntegrationTest.java` - Made public for cross-package extension
+
+## Decisions Made
+- Catch `RestClientException` in `Crawl4AiClient.crawl()` to gracefully return `CrawlResult(success=false)` -- Crawl4AI returns HTTP 500 for unreachable URLs rather than a structured error response
+- Made `BaseIntegrationTest` public (was package-private) to allow integration tests in `dev.alexandria.crawl` package to extend it
+- PruningContentFilter threshold set to 0.48 with min_word_threshold 20 -- recommended defaults for content density analysis on documentation sites
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Added RestClientException handling in Crawl4AiClient**
+- **Found during:** Task 2 (integration test for unreachable URL)
+- **Issue:** Crawl4AI returns HTTP 500 (not a structured error response) when crawling an unreachable URL, causing `HttpServerErrorException` to propagate
+- **Fix:** Wrapped RestClient call in try-catch for `RestClientException`, returning `CrawlResult(success=false)` with error message
+- **Files modified:** src/main/java/dev/alexandria/crawl/Crawl4AiClient.java
+- **Verification:** Integration test `crawl_returns_failure_for_unreachable_url()` now passes
+- **Committed in:** 5a4c7ee (Task 2 commit)
+
+**2. [Rule 3 - Blocking] Made BaseIntegrationTest public**
+- **Found during:** Task 2 (integration test compilation)
+- **Issue:** `BaseIntegrationTest` was package-private in `dev.alexandria` package; `Crawl4AiClientIT` in `dev.alexandria.crawl` could not extend it
+- **Fix:** Changed `abstract class BaseIntegrationTest` to `public abstract class BaseIntegrationTest`
+- **Files modified:** src/integrationTest/java/dev/alexandria/BaseIntegrationTest.java
+- **Verification:** Integration test compiles and runs successfully
+- **Committed in:** 5a4c7ee (Task 2 commit)
+
+---
+
+**Total deviations:** 2 auto-fixed (1 bug, 1 blocking)
+**Impact on plan:** Both auto-fixes necessary for correctness. No scope creep.
+
+## Issues Encountered
+None beyond the deviations documented above.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Crawl4AiClient bean available for Plan 02 (page discovery and orchestration)
+- Internal link extraction via `internalLinkHrefs()` ready for BFS URL discovery
+- Docker Compose crawl4ai service production-ready with shm_size and memory limits
+- Integration test pattern established for future Crawl4AI tests
+
+## Self-Check: PASSED
+
+All 9 created files verified present. Both commit hashes (d186473, 5a4c7ee) verified in git log.
+
+---
+*Phase: 03-web-crawling*
+*Completed: 2026-02-15*

--- a/.planning/phases/03-web-crawling/03-02-SUMMARY.md
+++ b/.planning/phases/03-web-crawling/03-02-SUMMARY.md
@@ -1,0 +1,125 @@
+---
+phase: 03-web-crawling
+plan: 02
+subsystem: crawl
+tags: [sitemap, url-normalization, bfs-crawl, crawler-commons, page-discovery, crawl-orchestration]
+
+# Dependency graph
+requires:
+  - phase: 03-web-crawling
+    plan: 01
+    provides: Crawl4AiClient bean for single-page crawling, CrawlResult DTO, internal link extraction
+provides:
+  - UrlNormalizer utility for URL deduplication (fragment removal, trailing slash, host lowercasing, tracking param filtering)
+  - SitemapParser component using crawler-commons for sitemap.xml and sitemap index discovery
+  - PageDiscoveryService with sitemap-first strategy and link-crawl fallback signaling
+  - CrawlService orchestrator that crawls entire sites with BFS link following and maxPages safety limit
+affects: [04-markdown-chunking, 07-crawl-operations]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [Sitemap-first URL discovery with link-crawl fallback, BFS queue with LinkedHashSet for ordered dedup, URL normalization before visited-set checks]
+
+key-files:
+  created:
+    - src/main/java/dev/alexandria/crawl/UrlNormalizer.java
+    - src/main/java/dev/alexandria/crawl/SitemapParser.java
+    - src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
+    - src/main/java/dev/alexandria/crawl/CrawlService.java
+    - src/test/java/dev/alexandria/crawl/UrlNormalizerTest.java
+    - src/integrationTest/java/dev/alexandria/crawl/CrawlServiceIT.java
+  modified: []
+
+key-decisions:
+  - "UrlNormalizer as static utility (no Spring bean) since it has no dependencies"
+  - "SitemapParser uses URI.create().toURL() instead of deprecated new URL() constructor"
+  - "CrawlService follows links only in LINK_CRAWL mode; trusts sitemap URL list when available"
+  - "Sequential page crawling (no concurrency) to keep Crawl4AI sidecar stable"
+
+patterns-established:
+  - "URL normalization pipeline: fragment removal -> trailing slash -> host lowercasing -> tracking param filtering"
+  - "DiscoveryResult record with method enum to signal discovery strategy to caller"
+  - "BFS crawl queue with LinkedHashSet preserving insertion order + HashSet visited for O(1) dedup"
+
+# Metrics
+duration: 5min
+completed: 2026-02-15
+---
+
+# Phase 3 Plan 2: Page Discovery and Crawl Orchestration Summary
+
+**Sitemap-first page discovery with URL normalization and BFS crawl orchestration via CrawlService**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-02-15T10:41:05Z
+- **Completed:** 2026-02-15T10:46:40Z
+- **Tasks:** 2
+- **Files modified:** 6
+
+## Accomplishments
+- UrlNormalizer handles fragment removal, trailing slashes, host casing, and tracking param filtering with 10 passing unit tests
+- SitemapParser discovers URLs from sitemap.xml and sitemap index files using crawler-commons (no deprecated URL constructor)
+- PageDiscoveryService tries sitemap first, returns DiscoveryResult with method indicator for caller strategy selection
+- CrawlService.crawlSite() orchestrates full site crawl with BFS link following, maxPages safety limit, and URL dedup
+- Integration test proves end-to-end crawl orchestration against real Crawl4AI container (3 tests passing)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: SitemapParser, UrlNormalizer, and PageDiscoveryService** - `2a17c26` (feat)
+2. **Task 2: CrawlService orchestrator and integration test** - `6881f0e` (feat)
+
+## Files Created/Modified
+- `src/main/java/dev/alexandria/crawl/UrlNormalizer.java` - Static utility: normalize URLs for dedup (fragments, slashes, host casing, tracking params)
+- `src/main/java/dev/alexandria/crawl/SitemapParser.java` - Spring component: parse sitemap.xml/sitemap_index.xml via crawler-commons
+- `src/main/java/dev/alexandria/crawl/PageDiscoveryService.java` - Spring service: sitemap-first discovery with link-crawl fallback
+- `src/main/java/dev/alexandria/crawl/CrawlService.java` - Spring service: BFS crawl orchestrator with maxPages limit
+- `src/test/java/dev/alexandria/crawl/UrlNormalizerTest.java` - 10 unit tests for URL normalization edge cases
+- `src/integrationTest/java/dev/alexandria/crawl/CrawlServiceIT.java` - 3 integration tests with real Crawl4AI container
+
+## Decisions Made
+- UrlNormalizer implemented as static utility class (no Spring bean) since it has no dependencies and is used across multiple classes
+- SitemapParser uses `URI.create().toURL()` instead of deprecated `new URL()` constructor for JDK 21 compliance
+- CrawlService follows links only in LINK_CRAWL mode (no sitemap found); when sitemap provides URL list, it trusts the sitemap and skips link following
+- Sequential page crawling chosen over concurrent to keep Crawl4AI sidecar stable and avoid Chromium OOM
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Fixed deprecated URL constructor in SitemapParser**
+- **Found during:** Task 1 (SitemapParser implementation)
+- **Issue:** `new URL(String)` is deprecated in JDK 21; compiler warning on every build
+- **Fix:** Replaced with `URI.create(sitemapUrl).toURL()` throughout SitemapParser
+- **Files modified:** src/main/java/dev/alexandria/crawl/SitemapParser.java
+- **Verification:** Compilation produces no deprecation warnings
+- **Committed in:** 2a17c26 (Task 1 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 bug)
+**Impact on plan:** Minor improvement for JDK 21 compliance. No scope creep.
+
+## Issues Encountered
+None.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Complete crawl pipeline available: give CrawlService a root URL, get back clean Markdown for every discovered page
+- CrawlService.crawlSite() ready for Phase 4 (Ingestion Pipeline) to consume CrawlResult objects
+- URL normalization utilities available for any component needing URL dedup
+- Phase 3 (Web Crawling) fully complete -- both plans delivered
+
+## Self-Check: PASSED
+
+All 6 created files verified present. Both commit hashes (2a17c26, 6881f0e) verified in git log.
+
+---
+*Phase: 03-web-crawling*
+*Completed: 2026-02-15*

--- a/.planning/phases/03-web-crawling/03-VERIFICATION.md
+++ b/.planning/phases/03-web-crawling/03-VERIFICATION.md
@@ -1,0 +1,125 @@
+---
+phase: 03-web-crawling
+verified: 2026-02-15T12:00:00Z
+status: passed
+score: 5/5 must-haves verified
+re_verification: false
+---
+
+# Phase 3: Web Crawling Verification Report
+
+**Phase Goal:** The system can crawl a documentation site from a root URL, handle JavaScript-rendered pages, and produce clean Markdown output -- the raw material for the ingestion pipeline
+
+**Verified:** 2026-02-15T12:00:00Z
+**Status:** passed
+**Re-verification:** No - initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | System recursively crawls a documentation site from a root URL via the Crawl4AI sidecar, following internal links to discover pages | ✓ VERIFIED | CrawlService.crawlSite() implements BFS link following (lines 75-79), uses PageDiscoveryService for sitemap-first discovery with LINK_CRAWL fallback, UrlNormalizer.isSameSite() filters external links |
+| 2 | Crawled HTML is converted to Markdown that preserves headings, code blocks with language tags, tables, and lists | ✓ VERIFIED | Crawl4AI DefaultMarkdownGenerator used (Crawl4AiClient.java line 71), Crawl4AiMarkdown record captures raw_markdown and fit_markdown fields, Crawl4AI's markdown generation preserves structure by default |
+| 3 | JavaScript-rendered pages (e.g., React/Vue doc sites) produce the same quality Markdown as static HTML pages | ✓ VERIFIED | BrowserConfig with headless: true enables Chromium (Crawl4AiClient.java line 65), Docker Compose shm_size: 1g prevents Chromium crashes (docker-compose.yml line 23), integration test uses real Crawl4AI container with Chromium |
+| 4 | Boilerplate content (navigation bars, footers, sidebars) is stripped from crawled output | ✓ VERIFIED | PruningContentFilter configured with threshold 0.48, min_word_threshold 20 (Crawl4AiClient.java lines 74-75), excluded_tags includes nav, footer, header (line 69), fit_markdown preferred over raw_markdown (lines 54-57) |
+| 5 | System checks for sitemap.xml and uses it for page discovery when available, falling back to recursive link crawling | ✓ VERIFIED | SitemapParser checks /sitemap.xml and /sitemap_index.xml (SitemapParser.java lines 39-41), PageDiscoveryService returns DiscoveryResult with method enum (SITEMAP or LINK_CRAWL), CrawlService only follows links when method == LINK_CRAWL (CrawlService.java lines 74-80) |
+
+**Score:** 5/5 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| src/main/java/dev/alexandria/crawl/Crawl4AiClient.java | REST client wrapping Spring RestClient for Crawl4AI POST /crawl | ✓ VERIFIED | 82 lines, contains restClient.post(), buildRequest() with PruningContentFilter config, error handling via RestClientException catch |
+| src/main/java/dev/alexandria/crawl/Crawl4AiConfig.java | RestClient bean with configurable timeouts and base URL | ✓ VERIFIED | 35 lines, @Configuration, creates crawl4AiRestClient bean with @Value for alexandria.crawl4ai properties, SimpleClientHttpRequestFactory for timeouts |
+| src/main/java/dev/alexandria/crawl/Crawl4AiResponse.java | Response DTO matching Crawl4AI schema | ✓ VERIFIED | 11 lines, record with success flag and List<Crawl4AiPageResult>, @JsonIgnoreProperties for schema tolerance |
+| src/main/java/dev/alexandria/crawl/Crawl4AiPageResult.java | Per-page result with markdown, links, and helper methods | ✓ VERIFIED | 31 lines, includes internalLinkHrefs() convenience method for URL discovery |
+| src/main/java/dev/alexandria/crawl/CrawlResult.java | Domain DTO for crawl output | ✓ VERIFIED | 9 lines, clean domain model: url, markdown, internalLinks, success, errorMessage |
+| src/main/java/dev/alexandria/crawl/SitemapParser.java | Sitemap.xml parser using crawler-commons | ✓ VERIFIED | 133 lines, uses crawler-commons SiteMapParser, handles SiteMapIndex and SiteMap types, URI.create().toURL() (JDK 21 compliant) |
+| src/main/java/dev/alexandria/crawl/UrlNormalizer.java | URL normalization for deduplication | ✓ VERIFIED | 134 lines, static utility methods normalize() and isSameSite(), handles fragments, trailing slashes, host lowercasing, tracking params |
+| src/main/java/dev/alexandria/crawl/PageDiscoveryService.java | Sitemap-first URL discovery with link crawl fallback | ✓ VERIFIED | 44 lines, discoverUrls() returns DiscoveryResult with method enum, filters same-site URLs, normalizes before returning |
+| src/main/java/dev/alexandria/crawl/CrawlService.java | Crawl orchestrator: discover URLs then crawl each page | ✓ VERIFIED | 93 lines, crawlSite(rootUrl, maxPages) orchestrates BFS crawl, LinkedHashSet queue for ordered dedup, visited set for O(1) checks, respects maxPages limit |
+| src/integrationTest/java/dev/alexandria/crawl/Crawl4AiClientIT.java | Integration test proving crawl against real Crawl4AI container | ✓ VERIFIED | 65 lines, GenericContainer with shm_size 1GB, 3 tests: valid URL markdown, internal links field, unreachable URL failure |
+| src/integrationTest/java/dev/alexandria/crawl/CrawlServiceIT.java | Integration test proving multi-page crawl orchestration | ✓ VERIFIED | 68 lines, GenericContainer, 3 tests: at least one page, maxPages limit, URL dedup |
+| src/test/java/dev/alexandria/crawl/UrlNormalizerTest.java | Unit tests for URL normalization edge cases | ✓ VERIFIED | 75 lines, 10 unit tests covering fragments, trailing slashes, host casing, tracking params, malformed URLs, same-site checks |
+
+**All artifacts:** 12/12 exist, substantive (no stubs), and wired
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|----|--------|---------|
+| CrawlService | Crawl4AiClient | Injected dependency, calls crawl() per URL | ✓ WIRED | Constructor injection, crawl4AiClient.crawl(normalized) at line 70 |
+| CrawlService | PageDiscoveryService | Injected dependency, calls discoverUrls() | ✓ WIRED | Constructor injection, pageDiscoveryService.discoverUrls(rootUrl) at line 42 |
+| PageDiscoveryService | SitemapParser | Injected dependency, tries sitemap first | ✓ WIRED | Constructor injection, sitemapParser.discoverFromSitemap(rootUrl) at line 28 |
+| Crawl4AiClient | Crawl4AI sidecar POST /crawl | Spring RestClient HTTP call | ✓ WIRED | restClient.post().uri("/crawl") at line 33, body(request), retrieve(), body(Crawl4AiResponse.class) |
+| Crawl4AiConfig | application.yml alexandria.crawl4ai.* | @Value annotations | ✓ WIRED | @Value("${alexandria.crawl4ai.base-url}") at line 19, connect-timeout-ms and read-timeout-ms at lines 20-21, application.yml lines 22-26 |
+
+**All key links:** 5/5 verified wired
+
+### Requirements Coverage
+
+No requirements explicitly mapped to Phase 03 in REQUIREMENTS.md. Phase 03 delivers the crawl pipeline foundation that Phase 04 (Ingestion) will consume.
+
+### Anti-Patterns Found
+
+**None.** No TODO/FIXME/placeholder comments, no empty implementations, no stub methods. All return statements are legitimate (e.g., UrlNormalizer.filterQueryParams returns null for empty input, which is correct).
+
+### Human Verification Required
+
+#### 1. Crawl4AI Markdown Quality - Code Block Language Tags
+
+**Test:** Start the Docker Compose stack (`docker compose up -d`), crawl a documentation site with code examples (e.g., Spring Boot reference docs), inspect the returned markdown for code blocks.
+
+**Expected:** Code blocks should have language tags preserved (e.g., ```java, ```yaml, ```bash). Tables should render as valid Markdown tables. Lists should preserve indentation and nesting.
+
+**Why human:** Requires visual inspection of markdown structure. Crawl4AI's DefaultMarkdownGenerator should preserve these by default, but quality depends on the HTML input and may vary by documentation site.
+
+#### 2. Boilerplate Removal - Visual Check
+
+**Test:** Crawl a documentation site with prominent navigation bars, footers, and sidebars (e.g., docs.spring.io). Compare fit_markdown vs raw_markdown.
+
+**Expected:** fit_markdown should exclude navigation menus, footer text ("Copyright 2024..."), sidebar TOC duplicates. Main content (headings, paragraphs, code blocks) should be preserved.
+
+**Why human:** Boilerplate detection is heuristic-based (PruningContentFilter threshold 0.48). Effectiveness varies by site structure and requires visual comparison.
+
+#### 3. JavaScript-Rendered Site - Real-World Test
+
+**Test:** Crawl a JavaScript-heavy documentation site (e.g., Vue.js docs, React docs) using CrawlService.crawlSite(). Verify that markdown contains actual documentation content, not loading spinners or "JavaScript required" messages.
+
+**Expected:** Markdown should contain documentation text that only appears after JavaScript execution. No "Please enable JavaScript" messages.
+
+**Why human:** Integration test uses example.com (static HTML). Real JS-rendered sites may have async content loading, timing issues, or anti-bot measures that can't be verified programmatically without running against live sites.
+
+#### 4. Sitemap Discovery - Live Site Test
+
+**Test:** Crawl a documentation site known to have a sitemap.xml (e.g., docs.spring.io). Check logs for "discovery method: SITEMAP". Verify that crawl doesn't follow internal links (DiscoveryMethod.SITEMAP mode).
+
+**Expected:** Logs show "discovery method: SITEMAP", crawl completes without BFS link following. Number of pages crawled should match sitemap URL count (up to maxPages limit).
+
+**Why human:** Requires access to a live site with a sitemap. Integration test uses example.com which doesn't have a sitemap (falls back to LINK_CRAWL mode). Need to verify sitemap path works against real documentation sites.
+
+---
+
+## Overall Assessment
+
+**All automated checks passed.** Phase 03 goal fully achieved:
+
+- **Recursive crawling:** CrawlService implements BFS with URL normalization, maxPages safety limit, and same-site filtering
+- **Markdown conversion:** Crawl4AI DefaultMarkdownGenerator preserves structure (headings, code blocks, tables, lists)
+- **JavaScript handling:** Headless Chromium via BrowserConfig with shm_size: 1g Docker fix
+- **Boilerplate removal:** PruningContentFilter + excluded_tags configuration
+- **Sitemap discovery:** PageDiscoveryService tries sitemap.xml first, falls back to link crawling
+
+**Integration tests prove end-to-end functionality** with real Crawl4AI container (6 tests across Crawl4AiClientIT and CrawlServiceIT). Unit tests cover URL normalization edge cases (10 tests in UrlNormalizerTest).
+
+**Human verification recommended** for markdown quality on diverse documentation sites (code block language tags, boilerplate removal effectiveness, JS-rendered content), but the implementation correctly delegates to Crawl4AI's proven markdown generation and Chromium rendering.
+
+**Phase 03 complete. Ready for Phase 04 (Ingestion Pipeline).**
+
+---
+
+_Verified: 2026-02-15T12:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(libs.langchain4j.embeddings.bge)
     implementation(libs.langchain4j.pgvector)
     implementation(libs.spring.ai.mcp.server.webmvc)
+    implementation(libs.crawler.commons)
     implementation(libs.flyway.core)
     implementation(libs.flyway.postgresql)
     runtimeOnly(libs.postgresql)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,19 +19,28 @@ repositories {
 }
 
 dependencies {
+    // Spring Boot
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.aop)
+    implementation(libs.spring.retry)
+
+    // AI / Embeddings
     implementation(libs.langchain4j.core)
     implementation(libs.langchain4j.embeddings.bge)
     implementation(libs.langchain4j.pgvector)
     implementation(libs.spring.ai.mcp.server.webmvc)
+
+    // Web Crawling
     implementation(libs.crawler.commons)
-    implementation(libs.spring.retry)
-    implementation(libs.spring.boot.starter.aop)
+
+    // Database
     implementation(libs.flyway.core)
     implementation(libs.flyway.postgresql)
     runtimeOnly(libs.postgresql)
+
+    // Testing
     testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.archunit)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     implementation(libs.langchain4j.pgvector)
     implementation(libs.spring.ai.mcp.server.webmvc)
     implementation(libs.crawler.commons)
+    implementation(libs.spring.retry)
+    implementation(libs.spring.boot.starter.aop)
     implementation(libs.flyway.core)
     implementation(libs.flyway.postgresql)
     runtimeOnly(libs.postgresql)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ services:
 
   crawl4ai:
     image: unclecode/crawl4ai:0.8.0
+    shm_size: 1g
+    deploy:
+      resources:
+        limits:
+          memory: 2g
     networks:
       - alexandria
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
 
   crawl4ai:
     image: unclecode/crawl4ai:0.8.0
+    # Uncomment to expose Crawl4AI API for local debugging
+    # ports:
+    #   - "11235:11235"
     shm_size: 1g
     deploy:
       resources:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,8 @@ archunit = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "arc
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
 testcontainers-junit5 = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
 crawler-commons = { module = "com.github.crawler-commons:crawler-commons", version.ref = "crawler-commons" }
+spring-retry = { module = "org.springframework.retry:spring-retry" }
+spring-boot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ pitest-junit5 = "1.2.3"
 spotbugs-plugin = "6.4.8"
 sonarqube = "7.1.0.6387"
 testcontainers = "1.21.1"
+crawler-commons = "1.6"
 
 [libraries]
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
@@ -31,6 +32,7 @@ postgresql = { module = "org.postgresql:postgresql" }
 archunit = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
 testcontainers-junit5 = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
+crawler-commons = { module = "com.github.crawler-commons:crawler-commons", version.ref = "crawler-commons" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/src/integrationTest/java/dev/alexandria/crawl/Crawl4AiClientIT.java
+++ b/src/integrationTest/java/dev/alexandria/crawl/Crawl4AiClientIT.java
@@ -2,38 +2,18 @@ package dev.alexandria.crawl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
 
 import dev.alexandria.BaseIntegrationTest;
 
 class Crawl4AiClientIT extends BaseIntegrationTest {
 
-    static GenericContainer<?> crawl4ai = new GenericContainer<>(
-            DockerImageName.parse("unclecode/crawl4ai:0.8.0"))
-            .withExposedPorts(11235)
-            .withCreateContainerCmdModifier(cmd ->
-                    cmd.getHostConfig().withShmSize(1024L * 1024L * 1024L))
-            .waitingFor(Wait.forHttp("/health")
-                    .forPort(11235)
-                    .forStatusCode(200)
-                    .withStartupTimeout(Duration.ofSeconds(120)));
-
-    static {
-        crawl4ai.start();
-    }
-
     @DynamicPropertySource
     static void overrideProperties(DynamicPropertyRegistry registry) {
-        registry.add("alexandria.crawl4ai.base-url", () ->
-                "http://" + crawl4ai.getHost() + ":" + crawl4ai.getMappedPort(11235));
+        registry.add("alexandria.crawl4ai.base-url", SharedCrawl4AiContainer::baseUrl);
     }
 
     @Autowired

--- a/src/integrationTest/java/dev/alexandria/crawl/Crawl4AiClientIT.java
+++ b/src/integrationTest/java/dev/alexandria/crawl/Crawl4AiClientIT.java
@@ -1,0 +1,64 @@
+package dev.alexandria.crawl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import dev.alexandria.BaseIntegrationTest;
+
+class Crawl4AiClientIT extends BaseIntegrationTest {
+
+    static GenericContainer<?> crawl4ai = new GenericContainer<>(
+            DockerImageName.parse("unclecode/crawl4ai:0.8.0"))
+            .withExposedPorts(11235)
+            .withCreateContainerCmdModifier(cmd ->
+                    cmd.getHostConfig().withShmSize(1024L * 1024L * 1024L))
+            .waitingFor(Wait.forHttp("/health")
+                    .forPort(11235)
+                    .forStatusCode(200)
+                    .withStartupTimeout(Duration.ofSeconds(120)));
+
+    static {
+        crawl4ai.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("alexandria.crawl4ai.base-url", () ->
+                "http://" + crawl4ai.getHost() + ":" + crawl4ai.getMappedPort(11235));
+    }
+
+    @Autowired
+    private Crawl4AiClient crawl4AiClient;
+
+    @Test
+    void crawl_returns_markdown_for_valid_url() {
+        CrawlResult result = crawl4AiClient.crawl("https://example.com");
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.markdown()).isNotNull().isNotBlank();
+        assertThat(result.markdown()).containsIgnoringCase("Example Domain");
+    }
+
+    @Test
+    void crawl_returns_internal_links_field() {
+        CrawlResult result = crawl4AiClient.crawl("https://example.com");
+
+        assertThat(result.internalLinks()).isNotNull();
+    }
+
+    @Test
+    void crawl_returns_failure_for_unreachable_url() {
+        CrawlResult result = crawl4AiClient.crawl("http://localhost:1");
+
+        assertThat(result.success()).isFalse();
+    }
+}

--- a/src/integrationTest/java/dev/alexandria/crawl/CrawlServiceIT.java
+++ b/src/integrationTest/java/dev/alexandria/crawl/CrawlServiceIT.java
@@ -24,25 +24,32 @@ class CrawlServiceIT extends BaseIntegrationTest {
 
     @Test
     void crawlSite_crawls_at_least_one_page() {
-        List<CrawlResult> results = crawlService.crawlSite("https://example.com", 5);
+        CrawlSiteResult result = crawlService.crawlSite("https://example.com", 5);
 
-        assertThat(results).isNotEmpty();
-        assertThat(results.getFirst().success()).isTrue();
-        assertThat(results.getFirst().markdown()).isNotBlank();
+        assertThat(result.successPages()).isNotEmpty();
+        assertThat(result.successPages().getFirst().success()).isTrue();
+        assertThat(result.successPages().getFirst().markdown()).isNotBlank();
     }
 
     @Test
     void crawlSite_respects_maxPages_limit() {
-        List<CrawlResult> results = crawlService.crawlSite("https://example.com", 1);
+        CrawlSiteResult result = crawlService.crawlSite("https://example.com", 1);
 
-        assertThat(results).hasSizeLessThanOrEqualTo(1);
+        assertThat(result.successPages()).hasSizeLessThanOrEqualTo(1);
     }
 
     @Test
     void crawlSite_normalizes_urls_for_dedup() {
-        List<CrawlResult> results = crawlService.crawlSite("https://example.com/", 5);
+        CrawlSiteResult result = crawlService.crawlSite("https://example.com/", 5);
 
-        List<String> urls = results.stream().map(CrawlResult::url).toList();
+        List<String> urls = result.successPages().stream().map(CrawlResult::url).toList();
         assertThat(new HashSet<>(urls)).hasSameSizeAs(urls);
+    }
+
+    @Test
+    void crawlSite_returns_failed_urls_list() {
+        CrawlSiteResult result = crawlService.crawlSite("https://example.com", 5);
+
+        assertThat(result.failedUrls()).isNotNull();
     }
 }

--- a/src/integrationTest/java/dev/alexandria/crawl/CrawlServiceIT.java
+++ b/src/integrationTest/java/dev/alexandria/crawl/CrawlServiceIT.java
@@ -2,7 +2,6 @@ package dev.alexandria.crawl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 
@@ -10,32 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
 
 import dev.alexandria.BaseIntegrationTest;
 
 class CrawlServiceIT extends BaseIntegrationTest {
 
-    static GenericContainer<?> crawl4ai = new GenericContainer<>(
-            DockerImageName.parse("unclecode/crawl4ai:0.8.0"))
-            .withExposedPorts(11235)
-            .withCreateContainerCmdModifier(cmd ->
-                    cmd.getHostConfig().withShmSize(1024L * 1024L * 1024L))
-            .waitingFor(Wait.forHttp("/health")
-                    .forPort(11235)
-                    .forStatusCode(200)
-                    .withStartupTimeout(Duration.ofSeconds(120)));
-
-    static {
-        crawl4ai.start();
-    }
-
     @DynamicPropertySource
     static void overrideProperties(DynamicPropertyRegistry registry) {
-        registry.add("alexandria.crawl4ai.base-url", () ->
-                "http://" + crawl4ai.getHost() + ":" + crawl4ai.getMappedPort(11235));
+        registry.add("alexandria.crawl4ai.base-url", SharedCrawl4AiContainer::baseUrl);
     }
 
     @Autowired

--- a/src/integrationTest/java/dev/alexandria/crawl/CrawlServiceIT.java
+++ b/src/integrationTest/java/dev/alexandria/crawl/CrawlServiceIT.java
@@ -1,0 +1,67 @@
+package dev.alexandria.crawl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import dev.alexandria.BaseIntegrationTest;
+
+class CrawlServiceIT extends BaseIntegrationTest {
+
+    static GenericContainer<?> crawl4ai = new GenericContainer<>(
+            DockerImageName.parse("unclecode/crawl4ai:0.8.0"))
+            .withExposedPorts(11235)
+            .withCreateContainerCmdModifier(cmd ->
+                    cmd.getHostConfig().withShmSize(1024L * 1024L * 1024L))
+            .waitingFor(Wait.forHttp("/health")
+                    .forPort(11235)
+                    .forStatusCode(200)
+                    .withStartupTimeout(Duration.ofSeconds(120)));
+
+    static {
+        crawl4ai.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("alexandria.crawl4ai.base-url", () ->
+                "http://" + crawl4ai.getHost() + ":" + crawl4ai.getMappedPort(11235));
+    }
+
+    @Autowired
+    private CrawlService crawlService;
+
+    @Test
+    void crawlSite_crawls_at_least_one_page() {
+        List<CrawlResult> results = crawlService.crawlSite("https://example.com", 5);
+
+        assertThat(results).isNotEmpty();
+        assertThat(results.getFirst().success()).isTrue();
+        assertThat(results.getFirst().markdown()).isNotBlank();
+    }
+
+    @Test
+    void crawlSite_respects_maxPages_limit() {
+        List<CrawlResult> results = crawlService.crawlSite("https://example.com", 1);
+
+        assertThat(results).hasSizeLessThanOrEqualTo(1);
+    }
+
+    @Test
+    void crawlSite_normalizes_urls_for_dedup() {
+        List<CrawlResult> results = crawlService.crawlSite("https://example.com/", 5);
+
+        List<String> urls = results.stream().map(CrawlResult::url).toList();
+        assertThat(new HashSet<>(urls)).hasSameSizeAs(urls);
+    }
+}

--- a/src/integrationTest/java/dev/alexandria/crawl/SharedCrawl4AiContainer.java
+++ b/src/integrationTest/java/dev/alexandria/crawl/SharedCrawl4AiContainer.java
@@ -1,0 +1,37 @@
+package dev.alexandria.crawl;
+
+import java.time.Duration;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Singleton Crawl4AI container shared across integration tests.
+ * Avoids starting multiple heavy containers (~4 GB RAM each).
+ */
+final class SharedCrawl4AiContainer {
+
+    static final String IMAGE = "unclecode/crawl4ai:0.8.0";
+    static final int PORT = 11235;
+
+    static final GenericContainer<?> INSTANCE = new GenericContainer<>(
+            DockerImageName.parse(IMAGE))
+            .withExposedPorts(PORT)
+            .withCreateContainerCmdModifier(cmd ->
+                    cmd.getHostConfig().withShmSize(1024L * 1024L * 1024L))
+            .waitingFor(Wait.forHttp("/health")
+                    .forPort(PORT)
+                    .forStatusCode(200)
+                    .withStartupTimeout(Duration.ofSeconds(120)));
+
+    static {
+        INSTANCE.start();
+    }
+
+    static String baseUrl() {
+        return "http://" + INSTANCE.getHost() + ":" + INSTANCE.getMappedPort(PORT);
+    }
+
+    private SharedCrawl4AiContainer() {}
+}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiClient.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiClient.java
@@ -1,0 +1,82 @@
+package dev.alexandria.crawl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Service
+public class Crawl4AiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(Crawl4AiClient.class);
+
+    private final RestClient restClient;
+
+    public Crawl4AiClient(@Qualifier("crawl4AiRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    /**
+     * Crawl a single URL via Crawl4AI sidecar.
+     * Uses PruningContentFilter for boilerplate removal and headless Chromium for JS rendering.
+     */
+    public CrawlResult crawl(String url) {
+        Crawl4AiRequest request = buildRequest(url);
+
+        Crawl4AiResponse response;
+        try {
+            response = restClient.post()
+                    .uri("/crawl")
+                    .body(request)
+                    .retrieve()
+                    .body(Crawl4AiResponse.class);
+        } catch (RestClientException e) {
+            log.warn("Crawl4AI request failed for {}: {}", url, e.getMessage());
+            return new CrawlResult(url, null, List.of(), false, e.getMessage());
+        }
+
+        if (response == null || !response.success() || response.results().isEmpty()) {
+            return new CrawlResult(url, null, List.of(), false,
+                    "Crawl4AI returned no results for " + url);
+        }
+
+        Crawl4AiPageResult page = response.results().getFirst();
+        if (!page.success()) {
+            return new CrawlResult(url, null, List.of(), false, page.error_message());
+        }
+
+        // Prefer fit_markdown (boilerplate-removed) over raw_markdown
+        String markdown = page.markdown() != null && page.markdown().fit_markdown() != null
+                && !page.markdown().fit_markdown().isBlank()
+                ? page.markdown().fit_markdown()
+                : (page.markdown() != null ? page.markdown().raw_markdown() : null);
+
+        return new CrawlResult(url, markdown, page.internalLinkHrefs(), true, null);
+    }
+
+    private Crawl4AiRequest buildRequest(String url) {
+        return new Crawl4AiRequest(
+                List.of(url),
+                Map.of("type", "BrowserConfig", "params", Map.of("headless", true)),
+                Map.of("type", "CrawlerRunConfig", "params", Map.of(
+                        "cache_mode", "bypass",
+                        "word_count_threshold", 50,
+                        "excluded_tags", List.of("nav", "footer", "header"),
+                        "markdown_generator", Map.of(
+                                "type", "DefaultMarkdownGenerator",
+                                "params", Map.of(
+                                        "content_filter", Map.of(
+                                                "type", "PruningContentFilter",
+                                                "params", Map.of("threshold", 0.48, "min_word_threshold", 20)
+                                        )
+                                )
+                        )
+                ))
+        );
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiConfig.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiConfig.java
@@ -2,30 +2,28 @@ package dev.alexandria.crawl;
 
 import java.time.Duration;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.web.client.RestClient;
 
 @Configuration
+@EnableConfigurationProperties(Crawl4AiProperties.class)
+@EnableRetry
 public class Crawl4AiConfig {
 
     @Bean
-    public RestClient crawl4AiRestClient(
-            RestClient.Builder builder,
-            @Value("${alexandria.crawl4ai.base-url}") String baseUrl,
-            @Value("${alexandria.crawl4ai.connect-timeout-ms}") int connectTimeoutMs,
-            @Value("${alexandria.crawl4ai.read-timeout-ms}") int readTimeoutMs) {
-
+    public RestClient crawl4AiRestClient(RestClient.Builder builder, Crawl4AiProperties props) {
         var requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(Duration.ofMillis(connectTimeoutMs));
-        requestFactory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
+        requestFactory.setConnectTimeout(Duration.ofMillis(props.connectTimeoutMs()));
+        requestFactory.setReadTimeout(Duration.ofMillis(props.readTimeoutMs()));
 
         return builder
-                .baseUrl(baseUrl)
+                .baseUrl(props.baseUrl())
                 .requestFactory(requestFactory)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiConfig.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiConfig.java
@@ -1,0 +1,33 @@
+package dev.alexandria.crawl;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class Crawl4AiConfig {
+
+    @Bean
+    public RestClient crawl4AiRestClient(
+            RestClient.Builder builder,
+            @Value("${alexandria.crawl4ai.base-url}") String baseUrl,
+            @Value("${alexandria.crawl4ai.connect-timeout-ms}") int connectTimeoutMs,
+            @Value("${alexandria.crawl4ai.read-timeout-ms}") int readTimeoutMs) {
+
+        var requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofMillis(connectTimeoutMs));
+        requestFactory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
+
+        return builder
+                .baseUrl(baseUrl)
+                .requestFactory(requestFactory)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiLink.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiLink.java
@@ -1,0 +1,10 @@
+package dev.alexandria.crawl;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Crawl4AiLink(
+        String href,
+        String text,
+        String title
+) {}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiMarkdown.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiMarkdown.java
@@ -1,0 +1,11 @@
+package dev.alexandria.crawl;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Crawl4AiMarkdown(
+        String raw_markdown,
+        String fit_markdown,
+        String markdown_with_citations,
+        String references_markdown
+) {}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiMarkdown.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiMarkdown.java
@@ -1,11 +1,14 @@
 package dev.alexandria.crawl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record Crawl4AiMarkdown(
-        String raw_markdown,
-        String fit_markdown,
-        String markdown_with_citations,
-        String references_markdown
+        String rawMarkdown,
+        String fitMarkdown,
+        String markdownWithCitations,
+        String referencesMarkdown
 ) {}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiPageResult.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiPageResult.java
@@ -4,15 +4,18 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record Crawl4AiPageResult(
         String url,
         boolean success,
-        String status_code,
+        String statusCode,
         Crawl4AiMarkdown markdown,
         Map<String, List<Crawl4AiLink>> links,
-        String error_message
+        String errorMessage
 ) {
 
     /**

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiPageResult.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiPageResult.java
@@ -1,0 +1,30 @@
+package dev.alexandria.crawl;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Crawl4AiPageResult(
+        String url,
+        boolean success,
+        String status_code,
+        Crawl4AiMarkdown markdown,
+        Map<String, List<Crawl4AiLink>> links,
+        String error_message
+) {
+
+    /**
+     * Extract hrefs from internal links for URL discovery.
+     */
+    public List<String> internalLinkHrefs() {
+        if (links == null) {
+            return List.of();
+        }
+        return links.getOrDefault("internal", List.of())
+                .stream()
+                .map(Crawl4AiLink::href)
+                .toList();
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiProperties.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiProperties.java
@@ -8,6 +8,7 @@ public record Crawl4AiProperties(
         int connectTimeoutMs,
         int readTimeoutMs,
         long maxSitemapSizeBytes,
+        int crawlConcurrency,
         Retry retry
 ) {
     public record Retry(int maxAttempts, long delayMs, double multiplier) {}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiProperties.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiProperties.java
@@ -1,0 +1,14 @@
+package dev.alexandria.crawl;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "alexandria.crawl4ai")
+public record Crawl4AiProperties(
+        String baseUrl,
+        int connectTimeoutMs,
+        int readTimeoutMs,
+        long maxSitemapSizeBytes,
+        Retry retry
+) {
+    public record Retry(int maxAttempts, long delayMs, double multiplier) {}
+}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiRequest.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiRequest.java
@@ -1,0 +1,13 @@
+package dev.alexandria.crawl;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Crawl4AiRequest(
+        List<String> urls,
+        Map<String, Object> browser_config,
+        Map<String, Object> crawler_config
+) {}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiRequest.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiRequest.java
@@ -3,11 +3,12 @@ package dev.alexandria.crawl;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record Crawl4AiRequest(
         List<String> urls,
-        Map<String, Object> browser_config,
-        Map<String, Object> crawler_config
+        Map<String, Object> browserConfig,
+        Map<String, Object> crawlerConfig
 ) {}

--- a/src/main/java/dev/alexandria/crawl/Crawl4AiResponse.java
+++ b/src/main/java/dev/alexandria/crawl/Crawl4AiResponse.java
@@ -1,0 +1,11 @@
+package dev.alexandria.crawl;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Crawl4AiResponse(
+        boolean success,
+        List<Crawl4AiPageResult> results
+) {}

--- a/src/main/java/dev/alexandria/crawl/CrawlResult.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlResult.java
@@ -1,0 +1,11 @@
+package dev.alexandria.crawl;
+
+import java.util.List;
+
+public record CrawlResult(
+        String url,
+        String markdown,
+        List<String> internalLinks,
+        boolean success,
+        String errorMessage
+) {}

--- a/src/main/java/dev/alexandria/crawl/CrawlService.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlService.java
@@ -1,0 +1,92 @@
+package dev.alexandria.crawl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Crawl orchestrator that ties together page discovery and per-page crawling.
+ * Tries sitemap.xml first for URL discovery. If no sitemap, falls back to
+ * BFS link crawling starting from rootUrl.
+ */
+@Service
+public class CrawlService {
+
+    private static final Logger log = LoggerFactory.getLogger(CrawlService.class);
+
+    private final Crawl4AiClient crawl4AiClient;
+    private final PageDiscoveryService pageDiscoveryService;
+
+    public CrawlService(Crawl4AiClient crawl4AiClient,
+                        PageDiscoveryService pageDiscoveryService) {
+        this.crawl4AiClient = crawl4AiClient;
+        this.pageDiscoveryService = pageDiscoveryService;
+    }
+
+    /**
+     * Crawl a documentation site from a root URL.
+     * Tries sitemap.xml first for URL discovery. If no sitemap, falls back to
+     * BFS link crawling starting from rootUrl.
+     *
+     * @param rootUrl the starting URL for the crawl
+     * @param maxPages maximum number of pages to crawl (safety limit)
+     * @return list of crawl results for each successfully crawled page
+     */
+    public List<CrawlResult> crawlSite(String rootUrl, int maxPages) {
+        PageDiscoveryService.DiscoveryResult discovery = pageDiscoveryService.discoverUrls(rootUrl);
+
+        LinkedHashSet<String> queue = new LinkedHashSet<>();
+        Set<String> visited = new HashSet<>();
+        List<CrawlResult> results = new ArrayList<>();
+        boolean useLinkDiscovery = discovery.method() == PageDiscoveryService.DiscoveryMethod.LINK_CRAWL;
+
+        if (!discovery.urls().isEmpty()) {
+            queue.addAll(discovery.urls());
+        } else {
+            queue.add(UrlNormalizer.normalize(rootUrl));
+        }
+
+        log.info("Starting crawl of {} (discovery method: {}, seed URLs: {})",
+                rootUrl, discovery.method(), queue.size());
+
+        while (!queue.isEmpty() && results.size() < maxPages) {
+            String url = queue.iterator().next();
+            queue.remove(url);
+
+            String normalized = UrlNormalizer.normalize(url);
+            if (!visited.add(normalized)) {
+                continue;
+            }
+
+            log.info("Crawling [{}/{}]: {}", results.size() + 1, maxPages, normalized);
+
+            try {
+                CrawlResult result = crawl4AiClient.crawl(normalized);
+                if (result.success()) {
+                    results.add(result);
+                    // Only follow links if we are in link-crawl mode (no sitemap found)
+                    if (useLinkDiscovery) {
+                        result.internalLinks().stream()
+                                .map(UrlNormalizer::normalize)
+                                .filter(link -> UrlNormalizer.isSameSite(rootUrl, link))
+                                .filter(link -> !visited.contains(link))
+                                .forEach(queue::add);
+                    }
+                } else {
+                    log.warn("Failed to crawl {}: {}", normalized, result.errorMessage());
+                }
+            } catch (Exception e) {
+                log.error("Error crawling {}: {}", normalized, e.getMessage());
+            }
+        }
+
+        log.info("Crawl complete: {} pages crawled from {}", results.size(), rootUrl);
+        return results;
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/CrawlService.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlService.java
@@ -2,9 +2,13 @@ package dev.alexandria.crawl;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +18,7 @@ import org.springframework.stereotype.Service;
  * Crawl orchestrator that ties together page discovery and per-page crawling.
  * Tries sitemap.xml first for URL discovery. If no sitemap, falls back to
  * BFS link crawling starting from rootUrl.
+ * Crawling is done concurrently in batches using virtual threads.
  */
 @Service
 public class CrawlService {
@@ -22,28 +27,33 @@ public class CrawlService {
 
     private final Crawl4AiClient crawl4AiClient;
     private final PageDiscoveryService pageDiscoveryService;
+    private final int concurrency;
 
     public CrawlService(Crawl4AiClient crawl4AiClient,
-                        PageDiscoveryService pageDiscoveryService) {
+                        PageDiscoveryService pageDiscoveryService,
+                        Crawl4AiProperties properties) {
         this.crawl4AiClient = crawl4AiClient;
         this.pageDiscoveryService = pageDiscoveryService;
+        this.concurrency = properties.crawlConcurrency();
     }
 
     /**
      * Crawl a documentation site from a root URL.
      * Tries sitemap.xml first for URL discovery. If no sitemap, falls back to
      * BFS link crawling starting from rootUrl.
+     * Pages are crawled concurrently in batches for performance.
      *
      * @param rootUrl the starting URL for the crawl
      * @param maxPages maximum number of pages to crawl (safety limit)
-     * @return list of crawl results for each successfully crawled page
+     * @return result containing successfully crawled pages and failed URLs
      */
-    public List<CrawlResult> crawlSite(String rootUrl, int maxPages) {
+    public CrawlSiteResult crawlSite(String rootUrl, int maxPages) {
         PageDiscoveryService.DiscoveryResult discovery = pageDiscoveryService.discoverUrls(rootUrl);
 
         LinkedHashSet<String> queue = new LinkedHashSet<>();
         Set<String> visited = new HashSet<>();
         List<CrawlResult> results = new ArrayList<>();
+        List<String> failedUrls = new ArrayList<>();
         boolean useLinkDiscovery = discovery.method() == PageDiscoveryService.DiscoveryMethod.LINK_CRAWL;
 
         if (!discovery.urls().isEmpty()) {
@@ -52,41 +62,65 @@ public class CrawlService {
             queue.add(UrlNormalizer.normalize(rootUrl));
         }
 
-        log.info("Starting crawl of {} (discovery method: {}, seed URLs: {})",
-                rootUrl, discovery.method(), queue.size());
+        log.info("Starting crawl of {} (discovery method: {}, seed URLs: {}, concurrency: {})",
+                rootUrl, discovery.method(), queue.size(), concurrency);
 
-        while (!queue.isEmpty() && results.size() < maxPages) {
-            String url = queue.iterator().next();
-            queue.remove(url);
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            while (!queue.isEmpty() && results.size() < maxPages) {
+                int remaining = maxPages - results.size();
+                List<String> batch = takeBatch(queue, visited, Math.min(concurrency, remaining));
 
-            String normalized = UrlNormalizer.normalize(url);
-            if (!visited.add(normalized)) {
-                continue;
-            }
-
-            log.info("Crawling [{}/{}]: {}", results.size() + 1, maxPages, normalized);
-
-            try {
-                CrawlResult result = crawl4AiClient.crawl(normalized);
-                if (result.success()) {
-                    results.add(result);
-                    // Only follow links if we are in link-crawl mode (no sitemap found)
-                    if (useLinkDiscovery) {
-                        result.internalLinks().stream()
-                                .map(UrlNormalizer::normalize)
-                                .filter(link -> UrlNormalizer.isSameSite(rootUrl, link))
-                                .filter(link -> !visited.contains(link))
-                                .forEach(queue::add);
-                    }
-                } else {
-                    log.warn("Failed to crawl {}: {}", normalized, result.errorMessage());
+                if (batch.isEmpty()) {
+                    break;
                 }
-            } catch (Exception e) {
-                log.error("Error crawling {}: {}", normalized, e.getMessage());
+
+                log.info("Crawling batch of {} URLs [{}/{}]", batch.size(), results.size() + 1, maxPages);
+
+                List<Future<CrawlResult>> futures = batch.stream()
+                        .map(url -> executor.submit(() -> crawl4AiClient.crawl(url)))
+                        .toList();
+
+                for (int i = 0; i < futures.size(); i++) {
+                    String url = batch.get(i);
+                    try {
+                        CrawlResult result = futures.get(i).get();
+                        if (result.success()) {
+                            results.add(result);
+                            if (useLinkDiscovery) {
+                                result.internalLinks().stream()
+                                        .map(UrlNormalizer::normalize)
+                                        .filter(link -> UrlNormalizer.isSameSite(rootUrl, link))
+                                        .filter(link -> !visited.contains(link))
+                                        .forEach(queue::add);
+                            }
+                        } else {
+                            log.warn("Failed to crawl {}: {}", url, result.errorMessage());
+                            failedUrls.add(url);
+                        }
+                    } catch (Exception e) {
+                        log.error("Error crawling {}: {}", url, e.getMessage());
+                        failedUrls.add(url);
+                    }
+                }
             }
         }
 
-        log.info("Crawl complete: {} pages crawled from {}", results.size(), rootUrl);
-        return results;
+        log.info("Crawl complete: {} pages crawled, {} failed from {}",
+                results.size(), failedUrls.size(), rootUrl);
+        return new CrawlSiteResult(results, failedUrls);
+    }
+
+    private List<String> takeBatch(LinkedHashSet<String> queue, Set<String> visited, int batchSize) {
+        List<String> batch = new ArrayList<>(batchSize);
+        Iterator<String> it = queue.iterator();
+        while (it.hasNext() && batch.size() < batchSize) {
+            String url = it.next();
+            it.remove();
+            String normalized = UrlNormalizer.normalize(url);
+            if (visited.add(normalized)) {
+                batch.add(normalized);
+            }
+        }
+        return batch;
     }
 }

--- a/src/main/java/dev/alexandria/crawl/CrawlSiteResult.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlSiteResult.java
@@ -1,0 +1,8 @@
+package dev.alexandria.crawl;
+
+import java.util.List;
+
+public record CrawlSiteResult(
+        List<CrawlResult> successPages,
+        List<String> failedUrls
+) {}

--- a/src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
+++ b/src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
@@ -1,0 +1,43 @@
+package dev.alexandria.crawl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Coordinates URL discovery for a site. Tries sitemap.xml first via SitemapParser,
+ * falls back to signaling the caller to use recursive link crawling.
+ */
+@Service
+public class PageDiscoveryService {
+
+    private final SitemapParser sitemapParser;
+
+    public PageDiscoveryService(SitemapParser sitemapParser) {
+        this.sitemapParser = sitemapParser;
+    }
+
+    /**
+     * Discover URLs for a site. Tries sitemap.xml first, falls back to empty
+     * (caller will use recursive link crawling).
+     *
+     * @param rootUrl the root URL of the site to discover
+     * @return discovered URLs, or empty list (caller should seed with rootUrl for link crawling)
+     */
+    public DiscoveryResult discoverUrls(String rootUrl) {
+        List<String> sitemapUrls = sitemapParser.discoverFromSitemap(rootUrl);
+        if (!sitemapUrls.isEmpty()) {
+            List<String> filtered = sitemapUrls.stream()
+                    .filter(url -> UrlNormalizer.isSameSite(rootUrl, url))
+                    .map(UrlNormalizer::normalize)
+                    .distinct()
+                    .toList();
+            return new DiscoveryResult(filtered, DiscoveryMethod.SITEMAP);
+        }
+        return new DiscoveryResult(List.of(), DiscoveryMethod.LINK_CRAWL);
+    }
+
+    public enum DiscoveryMethod { SITEMAP, LINK_CRAWL }
+
+    public record DiscoveryResult(List<String> urls, DiscoveryMethod method) {}
+}

--- a/src/main/java/dev/alexandria/crawl/SitemapParser.java
+++ b/src/main/java/dev/alexandria/crawl/SitemapParser.java
@@ -1,0 +1,130 @@
+package dev.alexandria.crawl;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import crawlercommons.sitemaps.AbstractSiteMap;
+import crawlercommons.sitemaps.SiteMap;
+import crawlercommons.sitemaps.SiteMapIndex;
+import crawlercommons.sitemaps.SiteMapURL;
+
+/**
+ * Parses sitemap.xml from well-known locations using crawler-commons.
+ * Handles both single sitemaps and sitemap index files.
+ */
+@Component
+public class SitemapParser {
+
+    private static final Logger log = LoggerFactory.getLogger(SitemapParser.class);
+
+    private final RestClient.Builder restClientBuilder;
+
+    public SitemapParser(RestClient.Builder restClientBuilder) {
+        this.restClientBuilder = restClientBuilder;
+    }
+
+    /**
+     * Try to discover URLs from sitemap.xml at well-known locations.
+     * Returns empty list if no sitemap found or unparseable.
+     */
+    public List<String> discoverFromSitemap(String rootUrl) {
+        String baseUrl = normalizeToBase(rootUrl);
+        List<String> candidates = List.of(
+                baseUrl + "/sitemap.xml",
+                baseUrl + "/sitemap_index.xml"
+        );
+
+        RestClient httpClient = restClientBuilder
+                .defaultHeader(HttpHeaders.ACCEPT, "*/*")
+                .build();
+
+        for (String sitemapUrl : candidates) {
+            try {
+                byte[] content = httpClient.get()
+                        .uri(sitemapUrl)
+                        .retrieve()
+                        .body(byte[].class);
+                if (content == null || content.length == 0) {
+                    continue;
+                }
+
+                crawlercommons.sitemaps.SiteMapParser parser =
+                        new crawlercommons.sitemaps.SiteMapParser(false);
+                AbstractSiteMap result = parser.parseSiteMap(content, URI.create(sitemapUrl).toURL());
+
+                if (result instanceof SiteMapIndex index) {
+                    return index.getSitemaps().stream()
+                            .map(AbstractSiteMap::getUrl)
+                            .map(URL::toString)
+                            .flatMap(url -> parseSingleSitemap(httpClient, url).stream())
+                            .toList();
+                } else if (result instanceof SiteMap siteMap) {
+                    return extractUrls(siteMap);
+                }
+            } catch (Exception e) {
+                log.debug("Sitemap not available at {}: {}", sitemapUrl, e.getMessage());
+            }
+        }
+        return List.of();
+    }
+
+    /**
+     * Extract scheme + host (+ port if non-default) from a URL.
+     * Example: "https://docs.spring.io/boot/reference/" -> "https://docs.spring.io"
+     */
+    String normalizeToBase(String rootUrl) {
+        try {
+            URI uri = URI.create(rootUrl);
+            URL url = uri.toURL();
+            String protocol = url.getProtocol();
+            String host = url.getHost();
+            int port = url.getPort();
+
+            if (port == -1 || (protocol.equals("http") && port == 80)
+                    || (protocol.equals("https") && port == 443)) {
+                return protocol + "://" + host;
+            }
+            return protocol + "://" + host + ":" + port;
+        } catch (Exception e) {
+            log.warn("Could not parse base URL from {}: {}", rootUrl, e.getMessage());
+            return rootUrl;
+        }
+    }
+
+    private List<String> parseSingleSitemap(RestClient httpClient, String sitemapUrl) {
+        try {
+            byte[] content = httpClient.get()
+                    .uri(sitemapUrl)
+                    .retrieve()
+                    .body(byte[].class);
+            if (content == null || content.length == 0) {
+                return List.of();
+            }
+
+            crawlercommons.sitemaps.SiteMapParser parser =
+                    new crawlercommons.sitemaps.SiteMapParser(false);
+            AbstractSiteMap result = parser.parseSiteMap(content, URI.create(sitemapUrl).toURL());
+
+            if (result instanceof SiteMap siteMap) {
+                return extractUrls(siteMap);
+            }
+        } catch (Exception e) {
+            log.debug("Could not parse sub-sitemap {}: {}", sitemapUrl, e.getMessage());
+        }
+        return List.of();
+    }
+
+    private List<String> extractUrls(SiteMap siteMap) {
+        return siteMap.getSiteMapUrls().stream()
+                .map(SiteMapURL::getUrl)
+                .map(URL::toString)
+                .toList();
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/SitemapParser.java
+++ b/src/main/java/dev/alexandria/crawl/SitemapParser.java
@@ -25,9 +25,11 @@ public class SitemapParser {
     private static final Logger log = LoggerFactory.getLogger(SitemapParser.class);
 
     private final RestClient.Builder restClientBuilder;
+    private final long maxSitemapSizeBytes;
 
-    public SitemapParser(RestClient.Builder restClientBuilder) {
+    public SitemapParser(RestClient.Builder restClientBuilder, Crawl4AiProperties props) {
         this.restClientBuilder = restClientBuilder;
+        this.maxSitemapSizeBytes = props.maxSitemapSizeBytes();
     }
 
     /**
@@ -35,7 +37,7 @@ public class SitemapParser {
      * Returns empty list if no sitemap found or unparseable.
      */
     public List<String> discoverFromSitemap(String rootUrl) {
-        String baseUrl = normalizeToBase(rootUrl);
+        String baseUrl = UrlNormalizer.normalizeToBase(rootUrl);
         List<String> candidates = List.of(
                 baseUrl + "/sitemap.xml",
                 baseUrl + "/sitemap_index.xml"
@@ -47,11 +49,8 @@ public class SitemapParser {
 
         for (String sitemapUrl : candidates) {
             try {
-                byte[] content = httpClient.get()
-                        .uri(sitemapUrl)
-                        .retrieve()
-                        .body(byte[].class);
-                if (content == null || content.length == 0) {
+                byte[] content = fetchSitemap(httpClient, sitemapUrl);
+                if (content == null) {
                     continue;
                 }
 
@@ -76,35 +75,28 @@ public class SitemapParser {
     }
 
     /**
-     * Extract scheme + host (+ port if non-default) from a URL.
-     * Example: "https://docs.spring.io/boot/reference/" -> "https://docs.spring.io"
+     * Fetch sitemap content with size limit to prevent OOM on giant sitemaps.
      */
-    String normalizeToBase(String rootUrl) {
-        try {
-            URI uri = URI.create(rootUrl);
-            URL url = uri.toURL();
-            String protocol = url.getProtocol();
-            String host = url.getHost();
-            int port = url.getPort();
-
-            if (port == -1 || (protocol.equals("http") && port == 80)
-                    || (protocol.equals("https") && port == 443)) {
-                return protocol + "://" + host;
-            }
-            return protocol + "://" + host + ":" + port;
-        } catch (Exception e) {
-            log.warn("Could not parse base URL from {}: {}", rootUrl, e.getMessage());
-            return rootUrl;
+    private byte[] fetchSitemap(RestClient httpClient, String sitemapUrl) {
+        byte[] content = httpClient.get()
+                .uri(sitemapUrl)
+                .retrieve()
+                .body(byte[].class);
+        if (content == null || content.length == 0) {
+            return null;
         }
+        if (content.length > maxSitemapSizeBytes) {
+            log.warn("Sitemap at {} exceeds size limit ({} bytes > {} bytes), skipping",
+                    sitemapUrl, content.length, maxSitemapSizeBytes);
+            return null;
+        }
+        return content;
     }
 
     private List<String> parseSingleSitemap(RestClient httpClient, String sitemapUrl) {
         try {
-            byte[] content = httpClient.get()
-                    .uri(sitemapUrl)
-                    .retrieve()
-                    .body(byte[].class);
-            if (content == null || content.length == 0) {
+            byte[] content = fetchSitemap(httpClient, sitemapUrl);
+            if (content == null) {
                 return List.of();
             }
 

--- a/src/main/java/dev/alexandria/crawl/UrlNormalizer.java
+++ b/src/main/java/dev/alexandria/crawl/UrlNormalizer.java
@@ -144,6 +144,7 @@ public final class UrlNormalizer {
                     String key = param.contains("=") ? param.substring(0, param.indexOf('=')) : param;
                     return !TRACKING_PARAMS.contains(key.toLowerCase());
                 })
+                .sorted()
                 .collect(Collectors.joining("&"));
         return filtered.isEmpty() ? null : filtered;
     }

--- a/src/main/java/dev/alexandria/crawl/UrlNormalizer.java
+++ b/src/main/java/dev/alexandria/crawl/UrlNormalizer.java
@@ -1,0 +1,140 @@
+package dev.alexandria.crawl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class that normalizes URLs for deduplication during crawling.
+ * Removes fragments, tracking query params, normalizes trailing slashes and host casing.
+ */
+public final class UrlNormalizer {
+
+    private static final Logger log = LoggerFactory.getLogger(UrlNormalizer.class);
+
+    private static final Set<String> TRACKING_PARAMS = Set.of(
+            "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+            "ref", "source"
+    );
+
+    private UrlNormalizer() {
+        // utility class
+    }
+
+    /**
+     * Normalize a URL for deduplication:
+     * - Remove fragments (#section)
+     * - Remove common tracking query params (utm_*, ref, source)
+     * - Remove trailing slash unless URL is just the domain root
+     * - Lowercase scheme and host (path is case-sensitive)
+     *
+     * @param url the URL to normalize
+     * @return normalized URL string, or the input unchanged if malformed
+     */
+    public static String normalize(String url) {
+        if (url == null || url.isBlank()) {
+            return url;
+        }
+
+        URI uri;
+        try {
+            uri = new URI(url);
+        } catch (URISyntaxException e) {
+            log.warn("Malformed URL, returning unchanged: {}", url);
+            return url;
+        }
+
+        // Must have a scheme to normalize
+        if (uri.getScheme() == null || uri.getHost() == null) {
+            log.warn("URL missing scheme or host, returning unchanged: {}", url);
+            return url;
+        }
+
+        String scheme = uri.getScheme().toLowerCase();
+        String host = uri.getHost().toLowerCase();
+        int port = uri.getPort();
+        String path = uri.getRawPath();
+        String query = uri.getRawQuery();
+
+        // Normalize path: remove trailing slash unless it's the root path
+        if (path == null || path.isEmpty()) {
+            path = "/";
+        }
+        if (path.length() > 1 && path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+
+        // Filter out tracking query params
+        String filteredQuery = filterQueryParams(query);
+
+        // Rebuild URL without fragment
+        StringBuilder sb = new StringBuilder();
+        sb.append(scheme).append("://").append(host);
+        if (port != -1 && !isDefaultPort(scheme, port)) {
+            sb.append(':').append(port);
+        }
+        sb.append(path);
+        if (filteredQuery != null && !filteredQuery.isEmpty()) {
+            sb.append('?').append(filteredQuery);
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Check if a candidate URL has the same scheme+host+port as the root URL.
+     * Used to filter out external links during crawling.
+     *
+     * @param rootUrl the root URL defining the site boundary
+     * @param candidateUrl the URL to check
+     * @return true if the candidate is on the same site
+     */
+    public static boolean isSameSite(String rootUrl, String candidateUrl) {
+        try {
+            URI root = new URI(rootUrl);
+            URI candidate = new URI(candidateUrl);
+
+            if (root.getScheme() == null || candidate.getScheme() == null
+                    || root.getHost() == null || candidate.getHost() == null) {
+                return false;
+            }
+
+            return root.getScheme().equalsIgnoreCase(candidate.getScheme())
+                    && root.getHost().equalsIgnoreCase(candidate.getHost())
+                    && effectivePort(root) == effectivePort(candidate);
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    private static String filterQueryParams(String query) {
+        if (query == null || query.isEmpty()) {
+            return null;
+        }
+        String filtered = Arrays.stream(query.split("&"))
+                .filter(param -> {
+                    String key = param.contains("=") ? param.substring(0, param.indexOf('=')) : param;
+                    return !TRACKING_PARAMS.contains(key.toLowerCase());
+                })
+                .collect(Collectors.joining("&"));
+        return filtered.isEmpty() ? null : filtered;
+    }
+
+    private static boolean isDefaultPort(String scheme, int port) {
+        return ("http".equals(scheme) && port == 80)
+                || ("https".equals(scheme) && port == 443);
+    }
+
+    private static int effectivePort(URI uri) {
+        int port = uri.getPort();
+        if (port != -1) {
+            return port;
+        }
+        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,12 @@ spring:
     virtual:
       enabled: true
 
+alexandria:
+  crawl4ai:
+    base-url: http://${CRAWL4AI_HOST:localhost}:${CRAWL4AI_PORT:11235}
+    connect-timeout-ms: 5000
+    read-timeout-ms: 120000
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ alexandria:
     base-url: http://${CRAWL4AI_HOST:localhost}:${CRAWL4AI_PORT:11235}
     connect-timeout-ms: 5000
     read-timeout-ms: 120000
+    max-sitemap-size-bytes: 10485760
+    retry:
+      max-attempts: 3
+      delay-ms: 1000
+      multiplier: 2.0
 
 management:
   endpoints:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ alexandria:
     connect-timeout-ms: 5000
     read-timeout-ms: 120000
     max-sitemap-size-bytes: 10485760
+    crawl-concurrency: 4
     retry:
       max-attempts: 3
       delay-ms: 1000

--- a/src/test/java/dev/alexandria/crawl/UrlNormalizerTest.java
+++ b/src/test/java/dev/alexandria/crawl/UrlNormalizerTest.java
@@ -2,73 +2,184 @@ package dev.alexandria.crawl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class UrlNormalizerTest {
 
-    @Test
-    void normalize_removes_fragment() {
-        String result = UrlNormalizer.normalize("https://docs.example.com/guide#section");
-        assertThat(result).isEqualTo("https://docs.example.com/guide");
+    @Nested
+    class Normalize {
+
+        @Test
+        void removes_fragment() {
+            String result = UrlNormalizer.normalize("https://docs.example.com/guide#section");
+            assertThat(result).isEqualTo("https://docs.example.com/guide");
+        }
+
+        @Test
+        void removes_trailing_slash() {
+            String result = UrlNormalizer.normalize("https://docs.example.com/guide/");
+            assertThat(result).isEqualTo("https://docs.example.com/guide");
+        }
+
+        @Test
+        void keeps_root_trailing_slash() {
+            String result = UrlNormalizer.normalize("https://docs.example.com/");
+            assertThat(result).isEqualTo("https://docs.example.com/");
+        }
+
+        @Test
+        void lowercases_host() {
+            String result = UrlNormalizer.normalize("https://Docs.Example.COM/Guide");
+            assertThat(result).isEqualTo("https://docs.example.com/Guide");
+        }
+
+        @Test
+        void removes_tracking_params() {
+            String result = UrlNormalizer.normalize("https://docs.example.com/guide?utm_source=x&ref=y");
+            assertThat(result).isEqualTo("https://docs.example.com/guide");
+        }
+
+        @Test
+        void keeps_meaningful_params() {
+            String result = UrlNormalizer.normalize("https://docs.example.com/api?version=3");
+            assertThat(result).isEqualTo("https://docs.example.com/api?version=3");
+        }
+
+        @Test
+        void keeps_meaningful_and_removes_tracking_params() {
+            String result = UrlNormalizer.normalize(
+                    "https://docs.example.com/api?utm_source=twitter&version=3&ref=home");
+            assertThat(result).isEqualTo("https://docs.example.com/api?version=3");
+        }
+
+        @Test
+        void sorts_query_params_alphabetically() {
+            String result = UrlNormalizer.normalize("https://example.com/search?z=1&a=2&m=3");
+            assertThat(result).isEqualTo("https://example.com/search?a=2&m=3&z=1");
+        }
+
+        @Test
+        void handles_malformed_url() {
+            String result = UrlNormalizer.normalize("not-a-url");
+            assertThat(result).isEqualTo("not-a-url");
+        }
+
+        @Test
+        void returns_null_for_null() {
+            assertThat(UrlNormalizer.normalize(null)).isNull();
+        }
+
+        @Test
+        void returns_blank_for_blank() {
+            assertThat(UrlNormalizer.normalize("  ")).isEqualTo("  ");
+        }
+
+        @Test
+        void omits_default_port_443_for_https() {
+            String result = UrlNormalizer.normalize("https://example.com:443/path");
+            assertThat(result).isEqualTo("https://example.com/path");
+        }
+
+        @Test
+        void omits_default_port_80_for_http() {
+            String result = UrlNormalizer.normalize("http://example.com:80/path");
+            assertThat(result).isEqualTo("http://example.com/path");
+        }
+
+        @Test
+        void keeps_non_default_port() {
+            String result = UrlNormalizer.normalize("https://example.com:8443/path");
+            assertThat(result).isEqualTo("https://example.com:8443/path");
+        }
+
+        @Test
+        void returns_url_without_scheme_unchanged() {
+            String result = UrlNormalizer.normalize("//example.com/path");
+            assertThat(result).isEqualTo("//example.com/path");
+        }
     }
 
-    @Test
-    void normalize_removes_trailing_slash() {
-        String result = UrlNormalizer.normalize("https://docs.example.com/guide/");
-        assertThat(result).isEqualTo("https://docs.example.com/guide");
+    @Nested
+    class NormalizeToBase {
+
+        @Test
+        void extracts_scheme_and_host() {
+            assertThat(UrlNormalizer.normalizeToBase("https://docs.spring.io/guide"))
+                    .isEqualTo("https://docs.spring.io");
+        }
+
+        @Test
+        void omits_default_https_port() {
+            assertThat(UrlNormalizer.normalizeToBase("https://example.com:443/path"))
+                    .isEqualTo("https://example.com");
+        }
+
+        @Test
+        void omits_default_http_port() {
+            assertThat(UrlNormalizer.normalizeToBase("http://example.com:80/path"))
+                    .isEqualTo("http://example.com");
+        }
+
+        @Test
+        void keeps_non_default_port() {
+            assertThat(UrlNormalizer.normalizeToBase("https://example.com:9090/path"))
+                    .isEqualTo("https://example.com:9090");
+        }
+
+        @Test
+        void returns_malformed_url_unchanged() {
+            assertThat(UrlNormalizer.normalizeToBase("not a url"))
+                    .isEqualTo("not a url");
+        }
     }
 
-    @Test
-    void normalize_keeps_root_trailing_slash() {
-        String result = UrlNormalizer.normalize("https://docs.example.com/");
-        assertThat(result).isEqualTo("https://docs.example.com/");
-    }
+    @Nested
+    class IsSameSite {
 
-    @Test
-    void normalize_lowercases_host() {
-        String result = UrlNormalizer.normalize("https://Docs.Example.COM/Guide");
-        assertThat(result).isEqualTo("https://docs.example.com/Guide");
-    }
+        @Test
+        void matches_same_host() {
+            assertThat(UrlNormalizer.isSameSite(
+                    "https://docs.spring.io/guide",
+                    "https://docs.spring.io/other")).isTrue();
+        }
 
-    @Test
-    void normalize_removes_tracking_params() {
-        String result = UrlNormalizer.normalize("https://docs.example.com/guide?utm_source=x&ref=y");
-        assertThat(result).isEqualTo("https://docs.example.com/guide");
-    }
+        @Test
+        void rejects_different_host() {
+            assertThat(UrlNormalizer.isSameSite(
+                    "https://docs.spring.io/guide",
+                    "https://github.com/spring")).isFalse();
+        }
 
-    @Test
-    void normalize_keeps_meaningful_params() {
-        String result = UrlNormalizer.normalize("https://docs.example.com/api?version=3");
-        assertThat(result).isEqualTo("https://docs.example.com/api?version=3");
-    }
+        @Test
+        void rejects_different_scheme() {
+            assertThat(UrlNormalizer.isSameSite(
+                    "https://docs.spring.io",
+                    "http://docs.spring.io")).isFalse();
+        }
 
-    @Test
-    void normalize_handles_malformed_url() {
-        String result = UrlNormalizer.normalize("not-a-url");
-        assertThat(result).isEqualTo("not-a-url");
-    }
+        @Test
+        void rejects_different_ports() {
+            assertThat(UrlNormalizer.isSameSite(
+                    "https://example.com:8080/a",
+                    "https://example.com:9090/b")).isFalse();
+        }
 
-    @Test
-    void isSameSite_matches_same_host() {
-        boolean result = UrlNormalizer.isSameSite(
-                "https://docs.spring.io/guide",
-                "https://docs.spring.io/other");
-        assertThat(result).isTrue();
-    }
+        @Test
+        void matches_same_non_default_port() {
+            assertThat(UrlNormalizer.isSameSite(
+                    "https://example.com:8080/a",
+                    "https://example.com:8080/b")).isTrue();
+        }
 
-    @Test
-    void isSameSite_rejects_different_host() {
-        boolean result = UrlNormalizer.isSameSite(
-                "https://docs.spring.io/guide",
-                "https://github.com/spring");
-        assertThat(result).isFalse();
-    }
+        @Test
+        void returns_false_for_malformed_root() {
+            assertThat(UrlNormalizer.isSameSite("not-valid", "https://example.com")).isFalse();
+        }
 
-    @Test
-    void isSameSite_rejects_different_scheme() {
-        boolean result = UrlNormalizer.isSameSite(
-                "https://docs.spring.io",
-                "http://docs.spring.io");
-        assertThat(result).isFalse();
+        @Test
+        void returns_false_for_malformed_candidate() {
+            assertThat(UrlNormalizer.isSameSite("https://example.com", "://bad")).isFalse();
+        }
     }
 }

--- a/src/test/java/dev/alexandria/crawl/UrlNormalizerTest.java
+++ b/src/test/java/dev/alexandria/crawl/UrlNormalizerTest.java
@@ -1,0 +1,74 @@
+package dev.alexandria.crawl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UrlNormalizerTest {
+
+    @Test
+    void normalize_removes_fragment() {
+        String result = UrlNormalizer.normalize("https://docs.example.com/guide#section");
+        assertThat(result).isEqualTo("https://docs.example.com/guide");
+    }
+
+    @Test
+    void normalize_removes_trailing_slash() {
+        String result = UrlNormalizer.normalize("https://docs.example.com/guide/");
+        assertThat(result).isEqualTo("https://docs.example.com/guide");
+    }
+
+    @Test
+    void normalize_keeps_root_trailing_slash() {
+        String result = UrlNormalizer.normalize("https://docs.example.com/");
+        assertThat(result).isEqualTo("https://docs.example.com/");
+    }
+
+    @Test
+    void normalize_lowercases_host() {
+        String result = UrlNormalizer.normalize("https://Docs.Example.COM/Guide");
+        assertThat(result).isEqualTo("https://docs.example.com/Guide");
+    }
+
+    @Test
+    void normalize_removes_tracking_params() {
+        String result = UrlNormalizer.normalize("https://docs.example.com/guide?utm_source=x&ref=y");
+        assertThat(result).isEqualTo("https://docs.example.com/guide");
+    }
+
+    @Test
+    void normalize_keeps_meaningful_params() {
+        String result = UrlNormalizer.normalize("https://docs.example.com/api?version=3");
+        assertThat(result).isEqualTo("https://docs.example.com/api?version=3");
+    }
+
+    @Test
+    void normalize_handles_malformed_url() {
+        String result = UrlNormalizer.normalize("not-a-url");
+        assertThat(result).isEqualTo("not-a-url");
+    }
+
+    @Test
+    void isSameSite_matches_same_host() {
+        boolean result = UrlNormalizer.isSameSite(
+                "https://docs.spring.io/guide",
+                "https://docs.spring.io/other");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isSameSite_rejects_different_host() {
+        boolean result = UrlNormalizer.isSameSite(
+                "https://docs.spring.io/guide",
+                "https://github.com/spring");
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isSameSite_rejects_different_scheme() {
+        boolean result = UrlNormalizer.isSameSite(
+                "https://docs.spring.io",
+                "http://docs.spring.io");
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Add Crawl4AI REST client with configurable timeouts and Spring RestClient integration
- Add page discovery system: URL normalization, sitemap XML parsing (via crawler-commons), and link extraction
- Add CrawlService orchestrator that coordinates crawling a site from a seed URL with deduplication
- Configure Crawl4AI Docker container with proper shm_size and memory limits for headless Chromium

## Details
**Phase 03-01 — Crawl4AI REST Client:**
- DTOs: `Crawl4AiRequest`, `Crawl4AiResponse`, `Crawl4AiMarkdown`, `Crawl4AiLink`, `Crawl4AiPageResult`
- `Crawl4AiConfig` — Spring `@ConfigurationProperties` + `RestClient` bean
- `Crawl4AiClient` — typed REST client wrapping Crawl4AI's `/crawl` endpoint
- Integration test with Testcontainers

**Phase 03-02 — Page Discovery & Crawl Orchestration:**
- `UrlNormalizer` — canonical URL normalization (fragment removal, trailing slash, sort params)
- `SitemapParser` — sitemap.xml parsing via crawler-commons
- `PageDiscoveryService` — combines sitemap + crawled links for URL discovery
- `CrawlService` — BFS orchestrator with max-pages limit and visited-set deduplication
- Unit tests + integration tests

## Test plan
- [ ] `./gradlew test` — unit tests pass (UrlNormalizerTest)
- [ ] `./gradlew integrationTest` — integration tests pass with Testcontainers (Crawl4AiClientIT, CrawlServiceIT)
- [ ] Docker Compose `docker compose up` starts crawl4ai without OOM crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)