### PR TITLE
feat: Phase 7 - Crawl Operations (scope, incremental, llms.txt, progress)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -17,36 +17,36 @@ Requirements for initial release. Each maps to roadmap phases.
 
 ### Crawling & Ingestion
 
-- [ ] **CRWL-01**: System crawls a documentation site recursively from a root URL via Crawl4AI sidecar
-- [ ] **CRWL-02**: System converts crawled HTML to Markdown preserving headings, code blocks with language tags, tables, and lists
-- [ ] **CRWL-03**: User can control crawl scope (URL pattern allowlist/blocklist, max depth, max pages)
-- [ ] **CRWL-04**: System handles JavaScript-rendered pages via Crawl4AI's Chromium headless browser
-- [ ] **CRWL-05**: System removes boilerplate content (navigation, footers, sidebars) from crawled pages
-- [ ] **CRWL-06**: System performs incremental/delta crawls — only re-processes pages whose content hash (SHA-256) has changed
-- [ ] **CRWL-07**: User can schedule periodic recrawls for a source (interval-based)
-- [ ] **CRWL-08**: System discovers pages via sitemap.xml when available, falls back to recursive crawl
-- [ ] **CRWL-09**: User can check crawl progress (pages crawled, pages remaining, errors) via MCP tool `crawl_status`
-- [ ] **CRWL-10**: User can trigger a recrawl of an existing source via MCP tool `recrawl_source`
-- [ ] **CRWL-11**: System can ingest llms.txt and llms-full.txt files as documentation sources and use them as page discovery mechanism (like sitemap.xml) for further crawling
+- [x] **CRWL-01**: System crawls a documentation site recursively from a root URL via Crawl4AI sidecar
+- [x] **CRWL-02**: System converts crawled HTML to Markdown preserving headings, code blocks with language tags, tables, and lists
+- [x] **CRWL-03**: User can control crawl scope (URL pattern allowlist/blocklist, max depth, max pages)
+- [x] **CRWL-04**: System handles JavaScript-rendered pages via Crawl4AI's Chromium headless browser
+- [x] **CRWL-05**: System removes boilerplate content (navigation, footers, sidebars) from crawled pages
+- [x] **CRWL-06**: System performs incremental/delta crawls — only re-processes pages whose content hash (SHA-256) has changed
+- [ ] **CRWL-07**: User can schedule periodic recrawls for a source (interval-based) *(deferred to manual recrawl_source)*
+- [x] **CRWL-08**: System discovers pages via sitemap.xml when available, falls back to recursive crawl
+- [x] **CRWL-09**: User can check crawl progress (pages crawled, pages remaining, errors) via MCP tool `crawl_status`
+- [x] **CRWL-10**: User can trigger a recrawl of an existing source via MCP tool `recrawl_source`
+- [x] **CRWL-11**: System can ingest llms.txt and llms-full.txt files as documentation sources and use them as page discovery mechanism (like sitemap.xml) for further crawling
 
 ### Chunking & Embedding
 
-- [ ] **CHUNK-01**: System chunks Markdown at heading boundaries (H1/H2/H3), never splitting mid-code-block or mid-table
-- [ ] **CHUNK-02**: System applies configurable chunk overlap (default 50-100 tokens)
-- [ ] **CHUNK-03**: Each chunk carries metadata: source URL, section path (breadcrumb), heading hierarchy, content type, last updated timestamp
-- [ ] **CHUNK-04**: System generates embeddings via ONNX in-process (bge-small-en-v1.5-q, 384 dimensions)
-- [ ] **CHUNK-05**: System extracts code examples as separate chunks tagged with language and content_type="code"
+- [x] **CHUNK-01**: System chunks Markdown at heading boundaries (H1/H2/H3), never splitting mid-code-block or mid-table
+- [x] **CHUNK-02**: System applies configurable chunk overlap (default 50-100 tokens)
+- [x] **CHUNK-03**: Each chunk carries metadata: source URL, section path (breadcrumb), heading hierarchy, content type, last updated timestamp
+- [x] **CHUNK-04**: System generates embeddings via ONNX in-process (bge-small-en-v1.5-q, 384 dimensions)
+- [x] **CHUNK-05**: System extracts code examples as separate chunks tagged with language and content_type="code"
 - [ ] **CHUNK-06**: User can tag each source with a version label (e.g., "React 19", "Spring Boot 3.5")
-- [ ] **CHUNK-07**: User can optionally provide pre-chunked content (from external tooling or LLM-assisted chunking) instead of relying on built-in automatic chunking
+- [x] **CHUNK-07**: User can optionally provide pre-chunked content (from external tooling or LLM-assisted chunking) instead of relying on built-in automatic chunking
 
 ### Search & Retrieval
 
-- [ ] **SRCH-01**: User can search indexed documentation via semantic vector search (cosine similarity, pgvector HNSW)
-- [ ] **SRCH-02**: User can search indexed documentation via keyword search (PostgreSQL tsvector/tsquery BM25)
-- [ ] **SRCH-03**: System combines vector and keyword results via Reciprocal Rank Fusion (RRF) for hybrid search
+- [x] **SRCH-01**: User can search indexed documentation via semantic vector search (cosine similarity, pgvector HNSW)
+- [x] **SRCH-02**: User can search indexed documentation via keyword search (PostgreSQL tsvector/tsquery BM25)
+- [x] **SRCH-03**: System combines vector and keyword results via Reciprocal Rank Fusion (RRF) for hybrid search
 - [ ] **SRCH-04**: User can filter search results by source name
-- [ ] **SRCH-05**: Every search result includes source URL and section path for citation
-- [ ] **SRCH-06**: User can configure number of results returned (default 10)
+- [x] **SRCH-05**: Every search result includes source URL and section path for citation
+- [x] **SRCH-06**: User can configure number of results returned (default 10)
 - [ ] **SRCH-07**: System re-ranks top candidates via cross-encoder model for improved precision
 - [ ] **SRCH-08**: User can filter search results by section path (e.g., "API Reference" only)
 - [ ] **SRCH-09**: User can filter search results by version tag
@@ -54,18 +54,18 @@ Requirements for initial release. Each maps to roadmap phases.
 
 ### MCP Server
 
-- [ ] **MCP-01**: Server communicates via stdio transport for Claude Code integration
-- [ ] **MCP-02**: Tools have clear, front-loaded descriptions optimized for LLM tool selection
-- [ ] **MCP-03**: Tool errors return structured, actionable messages (not stack traces)
-- [ ] **MCP-04**: Search results respect a configurable token budget (default 5000 tokens)
-- [ ] **MCP-05**: Server exposes maximum 6 tools: `search_docs`, `list_sources`, `add_source`, `remove_source`, `crawl_status`, `recrawl_source`
+- [x] **MCP-01**: Server communicates via stdio transport for Claude Code integration
+- [x] **MCP-02**: Tools have clear, front-loaded descriptions optimized for LLM tool selection
+- [x] **MCP-03**: Tool errors return structured, actionable messages (not stack traces)
+- [x] **MCP-04**: Search results respect a configurable token budget (default 5000 tokens)
+- [x] **MCP-05**: Server exposes maximum 6 tools: `search_docs`, `list_sources`, `add_source`, `remove_source`, `crawl_status`, `recrawl_source`
 
 ### Infrastructure
 
-- [ ] **INFRA-01**: System runs via single `docker compose up` command (Java app + Crawl4AI + PostgreSQL+pgvector)
-- [ ] **INFRA-02**: System works with sensible defaults, zero mandatory configuration beyond Docker
-- [ ] **INFRA-03**: Project includes Claude Code integration guide (.mcp.json configuration)
-- [ ] **INFRA-04**: System fits within 14 GB RAM budget (on 24 GB machine)
+- [x] **INFRA-01**: System runs via single `docker compose up` command (Java app + Crawl4AI + PostgreSQL+pgvector)
+- [x] **INFRA-02**: System works with sensible defaults, zero mandatory configuration beyond Docker
+- [x] **INFRA-03**: Project includes Claude Code integration guide (.mcp.json configuration)
+- [x] **INFRA-04**: System fits within 14 GB RAM budget (on 24 GB machine)
 
 ## v2 Requirements
 
@@ -105,49 +105,52 @@ Deferred to future release. Tracked but not in current roadmap.
 | SRC-03 | Phase 6 | Pending |
 | SRC-04 | Phase 6 | Pending |
 | SRC-05 | Phase 6 | Pending |
-| CRWL-01 | Phase 3 | Pending |
-| CRWL-02 | Phase 3 | Pending |
-| CRWL-03 | Phase 7 | Pending |
-| CRWL-04 | Phase 3 | Pending |
-| CRWL-05 | Phase 3 | Pending |
-| CRWL-06 | Phase 7 | Pending |
-| CRWL-07 | Phase 7 | Pending |
-| CRWL-08 | Phase 3 | Pending |
-| CRWL-09 | Phase 7 | Pending |
-| CRWL-10 | Phase 7 | Pending |
-| CRWL-11 | Phase 7 | Pending |
-| CHUNK-01 | Phase 4 | Pending |
-| CHUNK-02 | Phase 4 | Pending |
-| CHUNK-03 | Phase 4 | Pending |
-| CHUNK-04 | Phase 1 | Pending |
-| CHUNK-05 | Phase 4 | Pending |
+| CRWL-01 | Phase 3 | ✓ Complete |
+| CRWL-02 | Phase 3 | ✓ Complete |
+| CRWL-03 | Phase 7 | ✓ Complete |
+| CRWL-04 | Phase 3 | ✓ Complete |
+| CRWL-05 | Phase 3 | ✓ Complete |
+| CRWL-06 | Phase 7 | ✓ Complete |
+| CRWL-07 | Phase 7 | Deferred (manual recrawl_source) |
+| CRWL-08 | Phase 3 | ✓ Complete |
+| CRWL-09 | Phase 7 | ✓ Complete |
+| CRWL-10 | Phase 7 | ✓ Complete |
+| CRWL-11 | Phase 7 | ✓ Complete |
+| CHUNK-01 | Phase 4 | ✓ Complete |
+| CHUNK-02 | Phase 4 | ✓ Complete |
+| CHUNK-03 | Phase 4 | ✓ Complete |
+| CHUNK-04 | Phase 1 | ✓ Complete |
+| CHUNK-05 | Phase 4 | ✓ Complete |
 | CHUNK-06 | Phase 8 | Pending |
-| CHUNK-07 | Phase 4 | Pending |
-| SRCH-01 | Phase 2 | Pending |
-| SRCH-02 | Phase 2 | Pending |
-| SRCH-03 | Phase 2 | Pending |
+| CHUNK-07 | Phase 4 | ✓ Complete |
+| SRCH-01 | Phase 2 | ✓ Complete |
+| SRCH-02 | Phase 2 | ✓ Complete |
+| SRCH-03 | Phase 2 | ✓ Complete |
 | SRCH-04 | Phase 8 | Pending |
-| SRCH-05 | Phase 2 | Pending |
-| SRCH-06 | Phase 2 | Pending |
+| SRCH-05 | Phase 2 | ✓ Complete |
+| SRCH-06 | Phase 2 | ✓ Complete |
 | SRCH-07 | Phase 8 | Pending |
 | SRCH-08 | Phase 8 | Pending |
 | SRCH-09 | Phase 8 | Pending |
 | SRCH-10 | Phase 8 | Pending |
-| MCP-01 | Phase 5 | Pending |
-| MCP-02 | Phase 5 | Pending |
-| MCP-03 | Phase 5 | Pending |
-| MCP-04 | Phase 5 | Pending |
-| MCP-05 | Phase 5 | Pending |
-| INFRA-01 | Phase 1 | Pending |
-| INFRA-02 | Phase 1 | Pending |
-| INFRA-03 | Phase 5 | Pending |
-| INFRA-04 | Phase 1 | Pending |
+| MCP-01 | Phase 5 | ✓ Complete |
+| MCP-02 | Phase 5 | ✓ Complete |
+| MCP-03 | Phase 5 | ✓ Complete |
+| MCP-04 | Phase 5 | ✓ Complete |
+| MCP-05 | Phase 5 | ✓ Complete |
+| INFRA-01 | Phase 1 | ✓ Complete |
+| INFRA-02 | Phase 1 | ✓ Complete |
+| INFRA-03 | Phase 5 | ✓ Complete |
+| INFRA-04 | Phase 1 | ✓ Complete |
 
 **Coverage:**
-- v1 requirements: 40 total
-- Mapped to phases: 40
+- v1 requirements: 42 total
+- Mapped to phases: 42
 - Unmapped: 0
+- Complete: 30/42 (71%)
+- Pending: 11 (SRC-01..05, CHUNK-06, SRCH-04, SRCH-07..10)
+- Deferred: 1 (CRWL-07)
 
 ---
 *Requirements defined: 2026-02-14*
-*Last updated: 2026-02-14 after roadmap creation*
+*Last updated: 2026-02-20 after phase 7 completion*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -20,7 +20,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [x] **Phase 4.5: Code Quality & Test Consolidation** *(INSERTED)* - Consolidate tests, increase coverage, refactor long methods, codebase cleanup (completed 2026-02-19)
 - [x] **Phase 5: MCP Server** - stdio transport exposing search and management tools to Claude Code
 - [ ] **Phase 6: Source Management** - CRUD operations for documentation sources with status tracking
-- [ ] **Phase 7: Crawl Operations** - Incremental crawls, scope controls, scheduling, progress monitoring
+- [x] **Phase 7: Crawl Operations** - Incremental crawls, scope controls, scheduling, progress monitoring (completed 2026-02-20)
 - [ ] **Phase 8: Advanced Search & Quality** - Cross-encoder reranking, filtering by section/version/content-type
 
 ## Phase Details
@@ -169,7 +169,7 @@ Plans:
   4. User can check crawl progress (pages crawled, pages remaining, errors) via `crawl_status` MCP tool
   5. User can trigger a manual recrawl of an existing source via `recrawl_source` MCP tool
   6. System can ingest llms.txt and llms-full.txt files as documentation sources and use them for page discovery
-**Plans:** 5 plans
+**Plans:** 5/5 plans complete
 
 Plans:
 - [x] 07-01-PLAN.md -- TDD pure crawl utilities: CrawlScope, UrlScopeFilter, ContentHasher
@@ -212,7 +212,7 @@ Note: Phase 4.5 is an urgent insertion for code quality consolidation before MCP
 | 4.5. Code Quality & Test Consolidation | 1/5 | Complete    | 2026-02-19 |
 | 5. MCP Server | 2/2 | Complete    | 2026-02-20 |
 | 6. Source Management | 0/TBD | Not started | - |
-| 7. Crawl Operations | 5/5 | Complete | 2026-02-20 |
+| 7. Crawl Operations | 5/5 | Complete    | 2026-02-20 |
 | 8. Advanced Search & Quality | 0/TBD | Not started | - |
 
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -175,7 +175,7 @@ Plans:
 - [x] 07-01-PLAN.md -- TDD pure crawl utilities: CrawlScope, UrlScopeFilter, ContentHasher
 - [x] 07-02-PLAN.md -- TDD LlmsTxtParser for llms.txt/llms-full.txt URL extraction
 - [x] 07-03-PLAN.md -- Schema migration, Source scope fields, IngestionStateRepository, CrawlProgressTracker, PageDiscoveryService llms.txt cascade
-- [ ] 07-04-PLAN.md -- CrawlService evolution (scope, depth, incremental, progress, llms-full.txt hybrid)
+- [x] 07-04-PLAN.md -- CrawlService evolution (scope, depth, incremental, progress, llms-full.txt hybrid)
 - [ ] 07-05-PLAN.md -- MCP tool wiring (add_source, crawl_status, recrawl_source real implementations)
 
 ### Phase 8: Advanced Search & Quality

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -172,9 +172,9 @@ Plans:
 **Plans:** 5 plans
 
 Plans:
-- [ ] 07-01-PLAN.md -- TDD pure crawl utilities: CrawlScope, UrlScopeFilter, ContentHasher
-- [ ] 07-02-PLAN.md -- TDD LlmsTxtParser for llms.txt/llms-full.txt URL extraction
-- [ ] 07-03-PLAN.md -- Schema migration, Source scope fields, IngestionStateRepository, CrawlProgressTracker, PageDiscoveryService llms.txt cascade
+- [x] 07-01-PLAN.md -- TDD pure crawl utilities: CrawlScope, UrlScopeFilter, ContentHasher
+- [x] 07-02-PLAN.md -- TDD LlmsTxtParser for llms.txt/llms-full.txt URL extraction
+- [x] 07-03-PLAN.md -- Schema migration, Source scope fields, IngestionStateRepository, CrawlProgressTracker, PageDiscoveryService llms.txt cascade
 - [ ] 07-04-PLAN.md -- CrawlService evolution (scope, depth, incremental, progress, llms-full.txt hybrid)
 - [ ] 07-05-PLAN.md -- MCP tool wiring (add_source, crawl_status, recrawl_source real implementations)
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -12,11 +12,11 @@ Alexandria delivers a self-hosted RAG system that crawls, indexes, and exposes t
 
 Decimal phases appear between their surrounding integers in numeric order.
 
-- [ ] **Phase 0: CI & Quality Gate** - Local and GitHub CI with unit tests, integration tests, mutation testing, dead code detection, and architecture tests
-- [ ] **Phase 1: Foundation & Infrastructure** - PostgreSQL+pgvector schema, Spring Boot skeleton, ONNX embeddings, Docker Compose
+- [x] **Phase 0: CI & Quality Gate** - Local and GitHub CI with unit tests, integration tests, mutation testing, dead code detection, and architecture tests (completed 2026-02-14)
+- [x] **Phase 1: Foundation & Infrastructure** - PostgreSQL+pgvector schema, Spring Boot skeleton, ONNX embeddings, Docker Compose (completed 2026-02-14)
 - [x] **Phase 2: Core Search** - Hybrid search (vector + keyword + RRF) verifiable with test data
 - [x] **Phase 3: Web Crawling** - Crawl4AI sidecar integration for recursive JS-capable crawling
-- [ ] **Phase 4: Ingestion Pipeline** - Markdown-aware chunking, metadata enrichment, code extraction
+- [x] **Phase 4: Ingestion Pipeline** - Markdown-aware chunking, metadata enrichment, code extraction (completed 2026-02-18)
 - [x] **Phase 4.5: Code Quality & Test Consolidation** *(INSERTED)* - Consolidate tests, increase coverage, refactor long methods, codebase cleanup (completed 2026-02-19)
 - [x] **Phase 5: MCP Server** - stdio transport exposing search and management tools to Claude Code
 - [ ] **Phase 6: Source Management** - CRUD operations for documentation sources with status tracking
@@ -36,11 +36,11 @@ Decimal phases appear between their surrounding integers in numeric order.
   4. Dead code detection (via detekt/UnusedDeclarations or equivalent) flags unused code as build warnings or errors
   5. Architecture tests (via ArchUnit) enforce package dependency rules and architectural constraints
   6. CI pipeline completes in under 5 minutes for an empty/skeleton project
-**Plans:** 2 plans
+**Plans:** 2/2 plans complete
 
 Plans:
-- [ ] 00-01-PLAN.md -- Gradle project skeleton with all quality gate plugins configured and verified
-- [ ] 00-02-PLAN.md -- Local quality.sh script and GitHub Actions CI workflow with SonarCloud
+- [x] 00-01-PLAN.md -- Gradle project skeleton with all quality gate plugins configured and verified
+- [x] 00-02-PLAN.md -- Local quality.sh script and GitHub Actions CI workflow with SonarCloud
 
 ### Phase 1: Foundation & Infrastructure
 **Goal**: A running Docker Compose stack with PostgreSQL+pgvector, Spring Boot application, and in-process ONNX embedding generation -- the base layer everything else builds on
@@ -52,11 +52,11 @@ Plans:
   3. Application can store an embedding with metadata in pgvector and retrieve it by ID
   4. Total memory usage of the running stack stays under 14 GB on a 24 GB machine
   5. Database schema is managed by Flyway migrations (no manual SQL execution required)
-**Plans:** 2 plans
+**Plans:** 2/2 plans complete
 
 Plans:
-- [ ] 01-01-PLAN.md -- Gradle dependencies, Spring Boot dual-profile config, Docker Compose stack with pgvector/Crawl4AI/app
-- [ ] 01-02-PLAN.md -- Flyway migrations, LangChain4j ONNX embedding beans, integration test proving embed-store-retrieve
+- [x] 01-01-PLAN.md -- Gradle dependencies, Spring Boot dual-profile config, Docker Compose stack with pgvector/Crawl4AI/app
+- [x] 01-02-PLAN.md -- Flyway migrations, LangChain4j ONNX embedding beans, integration test proving embed-store-retrieve
 
 ### Phase 2: Core Search
 **Goal**: Users can perform hybrid semantic+keyword search over indexed documentation and get relevant, cited results -- verifiable with manually inserted test data before any crawling exists
@@ -68,7 +68,7 @@ Plans:
   3. Hybrid search combines vector and keyword results via Reciprocal Rank Fusion and returns better results than either method alone
   4. Every search result includes a source URL and section path suitable for citation
   5. User can configure the number of results returned (defaulting to 10)
-**Plans:** 2 plans
+**Plans:** 2/2 plans complete
 
 Plans:
 - [x] 02-01-PLAN.md -- V2 Flyway migration (GIN index fix), hybrid EmbeddingStore config, SearchService + domain DTOs
@@ -84,7 +84,7 @@ Plans:
   3. JavaScript-rendered pages (e.g., React/Vue doc sites) produce the same quality Markdown as static HTML pages
   4. Boilerplate content (navigation bars, footers, sidebars) is stripped from crawled output
   5. System checks for sitemap.xml and uses it for page discovery when available, falling back to recursive link crawling
-**Plans:** 2 plans
+**Plans:** 2/2 plans complete
 
 Plans:
 - [x] 03-01-PLAN.md -- Crawl4AI REST client, Spring RestClient config, request/response DTOs, Docker Compose shm_size fix, integration test
@@ -101,11 +101,11 @@ Plans:
   4. Code examples are extracted as separate chunks tagged with language and content_type="code"
   5. User can optionally provide pre-chunked content (from external tooling or LLM-assisted chunking) bypassing automatic chunking
   6. End-to-end pipeline works: crawl a real documentation site and produce searchable results via hybrid search
-**Plans**: TBD
+**Plans:** 2/2 plans complete
 
 Plans:
-- [ ] 04-01: TBD
-- [ ] 04-02: TBD
+- [x] 04-01-PLAN.md -- MarkdownChunker (CommonMark AST), DocumentChunkData record, LanguageDetector, TDD
+- [x] 04-02-PLAN.md -- IngestionService orchestrator, PreChunkedImporter, integration tests proving ingest-search roundtrip
 
 ### Phase 4.5: Code Quality & Test Consolidation *(INSERTED)*
 **Goal**: Consolidate and strengthen the test suite built over Phases 0-4, increase test coverage where it adds value, refactor overly long methods, and perform targeted codebase cleanup -- ensuring a solid, maintainable foundation before building the MCP integration layer
@@ -122,9 +122,9 @@ Plans:
 Plans:
 - [x] 04.5-01-PLAN.md -- SpotBugs fixes (23 findings), unused Gradle deps removal, test fixture builders
 - [x] 04.5-02-PLAN.md -- Kill PIT mutations (20 surviving) and refactor MarkdownChunker long methods
-- [ ] 04.5-03-PLAN.md -- Add unit tests for crawl package (CrawlService, Crawl4AiClient, PageDiscoveryService, SitemapParser) + refactor CrawlService
-- [ ] 04.5-04-PLAN.md -- Add unit tests for IngestionService and PreChunkedImporter
-- [ ] 04.5-05-PLAN.md -- Javadoc on 18 classes, test name harmonization (46 renames), IT consolidation, dead code/import cleanup
+- [x] 04.5-03-PLAN.md -- Add unit tests for crawl package (CrawlService, Crawl4AiClient, PageDiscoveryService, SitemapParser) + refactor CrawlService
+- [x] 04.5-04-PLAN.md -- Add unit tests for IngestionService and PreChunkedImporter
+- [x] 04.5-05-PLAN.md -- Javadoc on 18 classes, test name harmonization (46 renames), IT consolidation, dead code/import cleanup
 
 ### Phase 5: MCP Server
 **Goal**: Claude Code can connect to Alexandria via MCP stdio transport and search indexed documentation -- the integration layer that makes everything usable
@@ -204,15 +204,15 @@ Note: Phase 4.5 is an urgent insertion for code quality consolidation before MCP
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 0. CI & Quality Gate | 0/2 | Planned | - |
-| 1. Foundation & Infrastructure | 0/2 | Planned | - |
+| 0. CI & Quality Gate | 2/2 | ✓ Complete | 2026-02-14 |
+| 1. Foundation & Infrastructure | 2/2 | ✓ Complete | 2026-02-14 |
 | 2. Core Search | 2/2 | ✓ Complete | 2026-02-15 |
 | 3. Web Crawling | 2/2 | ✓ Complete | 2026-02-15 |
 | 4. Ingestion Pipeline | 2/2 | ✓ Complete | 2026-02-18 |
-| 4.5. Code Quality & Test Consolidation | 1/5 | Complete    | 2026-02-19 |
-| 5. MCP Server | 2/2 | Complete    | 2026-02-20 |
+| 4.5. Code Quality & Test Consolidation | 5/5 | ✓ Complete | 2026-02-19 |
+| 5. MCP Server | 2/2 | ✓ Complete | 2026-02-20 |
 | 6. Source Management | 0/TBD | Not started | - |
-| 7. Crawl Operations | 5/5 | Complete    | 2026-02-20 |
+| 7. Crawl Operations | 5/5 | ✓ Complete | 2026-02-20 |
 | 8. Advanced Search & Quality | 0/TBD | Not started | - |
 
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -176,7 +176,7 @@ Plans:
 - [x] 07-02-PLAN.md -- TDD LlmsTxtParser for llms.txt/llms-full.txt URL extraction
 - [x] 07-03-PLAN.md -- Schema migration, Source scope fields, IngestionStateRepository, CrawlProgressTracker, PageDiscoveryService llms.txt cascade
 - [x] 07-04-PLAN.md -- CrawlService evolution (scope, depth, incremental, progress, llms-full.txt hybrid)
-- [ ] 07-05-PLAN.md -- MCP tool wiring (add_source, crawl_status, recrawl_source real implementations)
+- [x] 07-05-PLAN.md -- MCP tool wiring (add_source, crawl_status, recrawl_source real implementations)
 
 ### Phase 8: Advanced Search & Quality
 **Goal**: Search results are more precise through cross-encoder reranking and richer filtering options -- the quality multiplier layer
@@ -212,7 +212,7 @@ Note: Phase 4.5 is an urgent insertion for code quality consolidation before MCP
 | 4.5. Code Quality & Test Consolidation | 1/5 | Complete    | 2026-02-19 |
 | 5. MCP Server | 2/2 | Complete    | 2026-02-20 |
 | 6. Source Management | 0/TBD | Not started | - |
-| 7. Crawl Operations | 0/TBD | Not started | - |
+| 7. Crawl Operations | 5/5 | Complete | 2026-02-20 |
 | 8. Advanced Search & Quality | 0/TBD | Not started | - |
 
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -169,11 +169,14 @@ Plans:
   4. User can check crawl progress (pages crawled, pages remaining, errors) via `crawl_status` MCP tool
   5. User can trigger a manual recrawl of an existing source via `recrawl_source` MCP tool
   6. System can ingest llms.txt and llms-full.txt files as documentation sources and use them for page discovery
-**Plans**: TBD
+**Plans:** 5 plans
 
 Plans:
-- [ ] 07-01: TBD
-- [ ] 07-02: TBD
+- [ ] 07-01-PLAN.md -- TDD pure crawl utilities: CrawlScope, UrlScopeFilter, ContentHasher
+- [ ] 07-02-PLAN.md -- TDD LlmsTxtParser for llms.txt/llms-full.txt URL extraction
+- [ ] 07-03-PLAN.md -- Schema migration, Source scope fields, IngestionStateRepository, CrawlProgressTracker, PageDiscoveryService llms.txt cascade
+- [ ] 07-04-PLAN.md -- CrawlService evolution (scope, depth, incremental, progress, llms-full.txt hybrid)
+- [ ] 07-05-PLAN.md -- MCP tool wiring (add_source, crawl_status, recrawl_source real implementations)
 
 ### Phase 8: Advanced Search & Quality
 **Goal**: Search results are more precise through cross-encoder reranking and richer filtering options -- the quality multiplier layer

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -100,6 +100,8 @@ Recent decisions affecting current work:
 - [05-02]: Pre-existing SpotBugs VA_FORMAT_STRING_USES_NEWLINE in TokenBudgetTruncator is intentional -- MCP stdio output uses Unix \n, not platform-dependent %n
 - [07-01]: PathMatcher glob on URL paths: java.nio.file.FileSystems.getDefault().getPathMatcher for pattern matching on URL path segments
 - [07-01]: Block patterns take priority over allow patterns in UrlScopeFilter (per user decision from plan)
+- [07-02]: LlmsTxtParser link index threshold 0.3 ratio: >= 30% markdown link lines classifies content as llms.txt link index
+- [07-02]: LlmsTxtResult as nested record in LlmsTxtParser (self-contained API, not separate file)
 
 ### Pending Todos
 
@@ -119,6 +121,6 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-20
-Stopped at: Completed 07-01-PLAN.md
-Resume file: .planning/phases/07-crawl-operations/07-01-SUMMARY.md
-Next: Execute 07-02-PLAN.md
+Stopped at: Completed 07-02-PLAN.md
+Resume file: .planning/phases/07-crawl-operations/07-02-SUMMARY.md
+Next: Execute 07-03-PLAN.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -115,6 +115,6 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-20
-Stopped at: Completed 05-02-PLAN.md (Phase 05 complete)
-Resume file: .planning/phases/05-mcp-server/05-02-SUMMARY.md
-Next: Phase 6 planning (Source Management) or next available phase
+Stopped at: Phase 7 context gathered
+Resume file: .planning/phases/07-crawl-operations/07-CONTEXT.md
+Next: /gsd:plan-phase 7

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -10,18 +10,18 @@ See: .planning/PROJECT.md (updated 2026-02-14)
 ## Current Position
 
 Phase: 7 of 8 (Crawl Operations)
-Plan: 3 of 5 in Phase 07
+Plan: 4 of 5 in Phase 07
 Status: Executing Phase 07
-Last activity: 2026-02-20 -- Completed 07-03 (Infrastructure Layer)
+Last activity: 2026-02-20 -- Completed 07-04 (Crawl Orchestration)
 
-Progress: [████████░░] 75%
+Progress: [████████░░] 78%
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 16
-- Average duration: 4.6min
-- Total execution time: 1.2 hours
+- Total plans completed: 17
+- Average duration: 4.8min
+- Total execution time: 1.4 hours
 
 **By Phase:**
 
@@ -34,8 +34,8 @@ Progress: [████████░░] 75%
 | 05-mcp-server | 2 | 6min | 3.0min |
 
 **Recent Trend:**
-- Last 5 plans: 11min, 3min, 3min, 5min, 5min
-- Trend: stable
+- Last 5 plans: 3min, 5min, 5min, 7min, 10min
+- Trend: increasing (complexity growing with orchestration plans)
 
 *Updated after each plan completion*
 | Phase 04.5 P03 | 5min | 2 tasks | 5 files |
@@ -46,6 +46,7 @@ Progress: [████████░░] 75%
 | Phase 07 P01 | 5min | 2 tasks | 6 files |
 | Phase 07 P02 | 5min | 1 task | 2 files |
 | Phase 07 P03 | 7min | 2 tasks | 11 files |
+| Phase 07 P04 | 10min | 2 tasks | 5 files |
 
 ## Accumulated Context
 
@@ -107,6 +108,10 @@ Recent decisions affecting current work:
 - [07-03]: CrawlScope.fromSource() factory instead of Source.toCrawlScope() to maintain unidirectional crawl->source dependency
 - [07-03]: Comma-separated TEXT columns for scope patterns (simplest JPA mapping, no Hibernate array type complexity)
 - [07-03]: Answer-based URI routing in PageDiscoveryService tests for RestClient mock chain
+- [07-04]: Incremental ingestion logic in CrawlService (not IngestionService) to avoid ArchUnit crawl<->ingestion package cycle
+- [07-04]: Removed ingest(List<CrawlResult>) from IngestionService to break ingestion->crawl dependency
+- [07-04]: deleteChunksForUrl() on IngestionService as URL-scoped chunk deletion abstraction
+- [07-04]: LinkedHashMap<URL, depth> for BFS depth tracking instead of LinkedHashSet
 
 ### Pending Todos
 
@@ -126,6 +131,6 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-20
-Stopped at: Completed 07-03-PLAN.md
-Resume file: .planning/phases/07-crawl-operations/07-03-SUMMARY.md
-Next: Execute 07-04-PLAN.md
+Stopped at: Completed 07-04-PLAN.md
+Resume file: .planning/phases/07-crawl-operations/07-04-SUMMARY.md
+Next: Execute 07-05-PLAN.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -10,11 +10,11 @@ See: .planning/PROJECT.md (updated 2026-02-14)
 ## Current Position
 
 Phase: 7 of 8 (Crawl Operations)
-Plan: 2 of 5 in Phase 07
+Plan: 3 of 5 in Phase 07
 Status: Executing Phase 07
-Last activity: 2026-02-20 -- Completed 07-02 (LlmsTxtParser TDD)
+Last activity: 2026-02-20 -- Completed 07-03 (Infrastructure Layer)
 
-Progress: [███████░░░] 70%
+Progress: [████████░░] 75%
 
 ## Performance Metrics
 
@@ -45,6 +45,7 @@ Progress: [███████░░░] 70%
 | Phase 05 P02 | 3min | 2 tasks | 3 files |
 | Phase 07 P01 | 5min | 2 tasks | 6 files |
 | Phase 07 P02 | 5min | 1 task | 2 files |
+| Phase 07 P03 | 7min | 2 tasks | 11 files |
 
 ## Accumulated Context
 
@@ -102,6 +103,10 @@ Recent decisions affecting current work:
 - [07-01]: Block patterns take priority over allow patterns in UrlScopeFilter (per user decision from plan)
 - [07-02]: LlmsTxtParser link index threshold 0.3 ratio: >= 30% markdown link lines classifies content as llms.txt link index
 - [07-02]: LlmsTxtResult as nested record in LlmsTxtParser (self-contained API, not separate file)
+- [07-03]: CrawlProgress.Status enum instead of SourceStatus to avoid crawl<->source package cycle (ArchUnit no_package_cycles)
+- [07-03]: CrawlScope.fromSource() factory instead of Source.toCrawlScope() to maintain unidirectional crawl->source dependency
+- [07-03]: Comma-separated TEXT columns for scope patterns (simplest JPA mapping, no Hibernate array type complexity)
+- [07-03]: Answer-based URI routing in PageDiscoveryService tests for RestClient mock chain
 
 ### Pending Todos
 
@@ -121,6 +126,6 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-20
-Stopped at: Completed 07-02-PLAN.md
-Resume file: .planning/phases/07-crawl-operations/07-02-SUMMARY.md
-Next: Execute 07-03-PLAN.md
+Stopped at: Completed 07-03-PLAN.md
+Resume file: .planning/phases/07-crawl-operations/07-03-SUMMARY.md
+Next: Execute 07-04-PLAN.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,23 +5,23 @@
 See: .planning/PROJECT.md (updated 2026-02-14)
 
 **Core value:** Claude Code peut trouver et retourner des extraits de documentation technique pertinents et precis pour n'importe quel framework ou librairie indexe, a la demande.
-**Current focus:** Phase 5 - MCP Server (complete)
+**Current focus:** Phase 7 - Crawl Operations (in progress)
 
 ## Current Position
 
-Phase: 5 of 8 (MCP Server)
-Plan: 2 of 2 in Phase 05
-Status: Phase 05 complete
-Last activity: 2026-02-20 -- Completed 05-02 (MCP unit tests + .mcp.json)
+Phase: 7 of 8 (Crawl Operations)
+Plan: 2 of 5 in Phase 07
+Status: Executing Phase 07
+Last activity: 2026-02-20 -- Completed 07-02 (LlmsTxtParser TDD)
 
-Progress: [██████░░░░] 62%
+Progress: [███████░░░] 70%
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 14
+- Total plans completed: 16
 - Average duration: 4.6min
-- Total execution time: 1.1 hours
+- Total execution time: 1.2 hours
 
 **By Phase:**
 
@@ -34,7 +34,7 @@ Progress: [██████░░░░] 62%
 | 05-mcp-server | 2 | 6min | 3.0min |
 
 **Recent Trend:**
-- Last 5 plans: 12min, 3min, 11min, 3min, 3min
+- Last 5 plans: 11min, 3min, 3min, 5min, 5min
 - Trend: stable
 
 *Updated after each plan completion*
@@ -43,6 +43,8 @@ Progress: [██████░░░░] 62%
 | Phase 04.5 P05 | 11min | 2 tasks | 38 files |
 | Phase 05 P01 | 3min | 2 tasks | 4 files |
 | Phase 05 P02 | 3min | 2 tasks | 3 files |
+| Phase 07 P01 | 5min | 2 tasks | 6 files |
+| Phase 07 P02 | 5min | 1 task | 2 files |
 
 ## Accumulated Context
 
@@ -96,6 +98,8 @@ Recent decisions affecting current work:
 - [05-01]: Source management tools are functional stubs (add_source/remove_source interact with DB, others query status) with future-update messages for crawl orchestration
 - [05-01]: First search result always included even if exceeding token budget (truncated at char level) to guarantee non-empty responses
 - [05-02]: Pre-existing SpotBugs VA_FORMAT_STRING_USES_NEWLINE in TokenBudgetTruncator is intentional -- MCP stdio output uses Unix \n, not platform-dependent %n
+- [07-01]: PathMatcher glob on URL paths: java.nio.file.FileSystems.getDefault().getPathMatcher for pattern matching on URL path segments
+- [07-01]: Block patterns take priority over allow patterns in UrlScopeFilter (per user decision from plan)
 
 ### Pending Todos
 
@@ -115,6 +119,6 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-20
-Stopped at: Phase 7 context gathered
-Resume file: .planning/phases/07-crawl-operations/07-CONTEXT.md
-Next: /gsd:plan-phase 7
+Stopped at: Completed 07-01-PLAN.md
+Resume file: .planning/phases/07-crawl-operations/07-01-SUMMARY.md
+Next: Execute 07-02-PLAN.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -138,4 +138,4 @@ None yet.
 Last session: 2026-02-20
 Stopped at: Completed 07-05-PLAN.md (Phase 07 complete)
 Resume file: .planning/phases/07-crawl-operations/07-05-SUMMARY.md
-Next: Phase 08 (Polish & Hardening)
+Next: Phase 08 (Advanced Search & Quality)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,23 +5,23 @@
 See: .planning/PROJECT.md (updated 2026-02-14)
 
 **Core value:** Claude Code peut trouver et retourner des extraits de documentation technique pertinents et precis pour n'importe quel framework ou librairie indexe, a la demande.
-**Current focus:** Phase 7 - Crawl Operations (in progress)
+**Current focus:** Phase 7 - Crawl Operations (complete)
 
 ## Current Position
 
 Phase: 7 of 8 (Crawl Operations)
-Plan: 4 of 5 in Phase 07
-Status: Executing Phase 07
-Last activity: 2026-02-20 -- Completed 07-04 (Crawl Orchestration)
+Plan: 5 of 5 in Phase 07 (COMPLETE)
+Status: Phase 07 complete
+Last activity: 2026-02-20 -- Completed 07-05 (MCP Tool Integration)
 
-Progress: [████████░░] 78%
+Progress: [█████████░] 87%
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 17
+- Total plans completed: 18
 - Average duration: 4.8min
-- Total execution time: 1.4 hours
+- Total execution time: 1.5 hours
 
 **By Phase:**
 
@@ -32,10 +32,11 @@ Progress: [████████░░] 78%
 | 03-web-crawling | 2 | 9min | 4.5min |
 | 04.5-code-quality-consolidation | 5 | 31min | 6.2min |
 | 05-mcp-server | 2 | 6min | 3.0min |
+| 07-crawl-operations | 5 | 33min | 6.6min |
 
 **Recent Trend:**
-- Last 5 plans: 3min, 5min, 5min, 7min, 10min
-- Trend: increasing (complexity growing with orchestration plans)
+- Last 5 plans: 5min, 5min, 7min, 10min, 6min
+- Trend: stabilizing (MCP integration faster than crawl orchestration)
 
 *Updated after each plan completion*
 | Phase 04.5 P03 | 5min | 2 tasks | 5 files |
@@ -47,6 +48,7 @@ Progress: [████████░░] 78%
 | Phase 07 P02 | 5min | 1 task | 2 files |
 | Phase 07 P03 | 7min | 2 tasks | 11 files |
 | Phase 07 P04 | 10min | 2 tasks | 5 files |
+| Phase 07 P05 | 6min | 2 tasks | 2 files |
 
 ## Accumulated Context
 
@@ -112,6 +114,9 @@ Recent decisions affecting current work:
 - [07-04]: Removed ingest(List<CrawlResult>) from IngestionService to break ingestion->crawl dependency
 - [07-04]: deleteChunksForUrl() on IngestionService as URL-scoped chunk deletion abstraction
 - [07-04]: LinkedHashMap<URL, depth> for BFS depth tracking instead of LinkedHashSet
+- [07-05]: dispatchCrawl as package-private method for testability -- spy pattern suppresses virtual thread in unit tests
+- [07-05]: Scope overrides on recrawl are one-time: CrawlScope built from overrides, Source entity unchanged
+- [07-05]: results.size() used for chunkCount on Source after crawl (page count proxy; actual chunk counts tracked internally by CrawlService)
 
 ### Pending Todos
 
@@ -131,6 +136,6 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-20
-Stopped at: Completed 07-04-PLAN.md
-Resume file: .planning/phases/07-crawl-operations/07-04-SUMMARY.md
-Next: Execute 07-05-PLAN.md
+Stopped at: Completed 07-05-PLAN.md (Phase 07 complete)
+Resume file: .planning/phases/07-crawl-operations/07-05-SUMMARY.md
+Next: Phase 08 (Polish & Hardening)

--- a/.planning/phases/07-crawl-operations/07-01-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-01-PLAN.md
@@ -1,0 +1,176 @@
+---
+phase: 07-crawl-operations
+plan: 01
+type: tdd
+wave: 1
+depends_on: []
+files_modified:
+  - src/main/java/dev/alexandria/crawl/CrawlScope.java
+  - src/main/java/dev/alexandria/crawl/UrlScopeFilter.java
+  - src/main/java/dev/alexandria/crawl/ContentHasher.java
+  - src/test/java/dev/alexandria/crawl/CrawlScopeTest.java
+  - src/test/java/dev/alexandria/crawl/UrlScopeFilterTest.java
+  - src/test/java/dev/alexandria/crawl/ContentHasherTest.java
+autonomous: true
+requirements:
+  - CRWL-03
+  - CRWL-06
+
+must_haves:
+  truths:
+    - "CrawlScope record holds immutable scope configuration (allow patterns, block patterns, max depth, max pages)"
+    - "UrlScopeFilter correctly filters URLs by glob patterns on URL paths, with block patterns taking priority"
+    - "ContentHasher produces deterministic SHA-256 hex strings from content"
+  artifacts:
+    - path: "src/main/java/dev/alexandria/crawl/CrawlScope.java"
+      provides: "Immutable scope config record"
+      contains: "record CrawlScope"
+    - path: "src/main/java/dev/alexandria/crawl/UrlScopeFilter.java"
+      provides: "Static URL scope filtering utility"
+      contains: "isAllowed"
+    - path: "src/main/java/dev/alexandria/crawl/ContentHasher.java"
+      provides: "SHA-256 content hashing utility"
+      contains: "sha256"
+    - path: "src/test/java/dev/alexandria/crawl/UrlScopeFilterTest.java"
+      provides: "Unit tests for URL scope filtering"
+      min_lines: 40
+    - path: "src/test/java/dev/alexandria/crawl/ContentHasherTest.java"
+      provides: "Unit tests for content hashing"
+      min_lines: 15
+  key_links:
+    - from: "src/main/java/dev/alexandria/crawl/UrlScopeFilter.java"
+      to: "src/main/java/dev/alexandria/crawl/CrawlScope.java"
+      via: "UrlScopeFilter.isAllowed takes CrawlScope parameter"
+      pattern: "isAllowed.*CrawlScope"
+    - from: "src/main/java/dev/alexandria/crawl/UrlScopeFilter.java"
+      to: "src/main/java/dev/alexandria/crawl/UrlNormalizer.java"
+      via: "isSameSite check before scope pattern matching"
+      pattern: "UrlNormalizer\\.isSameSite"
+---
+
+<objective>
+TDD-develop three pure utility classes for crawl scope control and content hashing: CrawlScope record, UrlScopeFilter static utility, and ContentHasher static utility.
+
+Purpose: These are the foundational building blocks for scope-limited crawling (CRWL-03) and incremental change detection (CRWL-06). All are pure functions with defined I/O, ideal for TDD.
+Output: Three production classes with comprehensive test suites.
+</objective>
+
+<execution_context>
+@./.claude/get-shit-done/workflows/execute-plan.md
+@./.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@src/main/java/dev/alexandria/crawl/UrlNormalizer.java
+@src/main/java/dev/alexandria/crawl/CrawlResult.java
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: TDD CrawlScope record and UrlScopeFilter utility</name>
+  <files>
+    src/main/java/dev/alexandria/crawl/CrawlScope.java
+    src/main/java/dev/alexandria/crawl/UrlScopeFilter.java
+    src/test/java/dev/alexandria/crawl/CrawlScopeTest.java
+    src/test/java/dev/alexandria/crawl/UrlScopeFilterTest.java
+  </files>
+  <action>
+    **RED phase: Write tests first.**
+
+    **CrawlScope record** (`crawl/CrawlScope.java`):
+    - Fields: `List<String> allowPatterns`, `List<String> blockPatterns`, `Integer maxDepth` (null = unlimited), `int maxPages`
+    - Compact constructor: null-safe `List.copyOf()` for both pattern lists (follow existing record pattern from CrawlResult)
+    - Default factory: `CrawlScope.withDefaults(int maxPages)` returning empty allow/block, null maxDepth
+
+    Tests for CrawlScope (`CrawlScopeTest`):
+    - `nullPatternsDefaultToEmptyLists` -- verify null allow/block become empty
+    - `patternsAreDefensivelyCopied` -- verify List.copyOf immutability
+    - `withDefaultsReturnsEmptyScope` -- verify factory method
+
+    **UrlScopeFilter** (`crawl/UrlScopeFilter.java`):
+    - Static utility class (private constructor), similar to UrlNormalizer pattern
+    - `public static boolean isAllowed(String url, String rootUrl, CrawlScope scope)`:
+      1. Check `UrlNormalizer.isSameSite(rootUrl, url)` first -- reject external URLs
+      2. Extract URL path using `URI.create(url).getPath()`
+      3. Check block patterns first: if any matches, return false (block takes priority per user decision)
+      4. If allowPatterns is non-empty, URL must match at least one allow pattern
+      5. If allowPatterns is empty, all same-site URLs are allowed
+    - Use `java.nio.file.FileSystems.getDefault().getPathMatcher("glob:" + pattern)` on `Path.of(urlPath)`
+    - Block pattern convention: strip `!` prefix before matching (user provides `!/docs/archive/**`, store as `/docs/archive/**` in blockPatterns list, or handle `!` at match time -- recommend stripping at parse time in CrawlScope, so blockPatterns stores clean patterns without `!`)
+
+    Tests for UrlScopeFilter (`UrlScopeFilterTest`):
+    - `externalUrlIsRejected` -- different host returns false
+    - `sameSiteUrlWithNoScopeIsAllowed` -- empty allow/block = allow all
+    - `urlMatchingAllowPatternIsAllowed` -- `/docs/api/v2` matches `/docs/**`
+    - `urlNotMatchingAllowPatternIsRejected` -- `/blog/post` does not match `/docs/**`
+    - `blockPatternTakesPriorityOverAllow` -- `/docs/archive/old` blocked by `/docs/archive/**` even though `/docs/**` allows it
+    - `rootPathSlashIsAllowed` -- edge case: path `/` with no patterns
+    - `multipleAllowPatternsAnyMatch` -- URL matching any of multiple allow patterns passes
+    - `malformedUrlReturnsFalse` -- graceful handling of bad input
+
+    **GREEN phase: Implement to pass tests.**
+
+    **REFACTOR: Clean up if needed.**
+  </action>
+  <verify>
+    `./quality.sh test` passes. All UrlScopeFilter and CrawlScope tests pass. Run `./gradlew test --tests "dev.alexandria.crawl.UrlScopeFilterTest" --tests "dev.alexandria.crawl.CrawlScopeTest"` to verify specifically.
+  </verify>
+  <done>CrawlScope record stores immutable scope config with null-safe defensive copies. UrlScopeFilter correctly filters URLs by glob patterns, with block patterns taking priority over allow patterns, and external URLs always rejected.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: TDD ContentHasher utility</name>
+  <files>
+    src/main/java/dev/alexandria/crawl/ContentHasher.java
+    src/test/java/dev/alexandria/crawl/ContentHasherTest.java
+  </files>
+  <action>
+    **RED phase: Write tests first.**
+
+    **ContentHasher** (`crawl/ContentHasher.java`):
+    - Static utility class (private constructor), same pattern as UrlNormalizer
+    - `public static String sha256(String content)`: returns lowercase hex string of SHA-256 hash
+    - Uses `java.security.MessageDigest.getInstance("SHA-256")` and `java.util.HexFormat.of().formatHex(hash)`
+    - `StandardCharsets.UTF_8` for encoding
+    - Wraps `NoSuchAlgorithmException` in `IllegalStateException` (SHA-256 always available)
+
+    Tests for ContentHasher (`ContentHasherTest`):
+    - `hashOfKnownInputMatchesExpected` -- verify against a known SHA-256 value (e.g., SHA-256 of "hello" = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+    - `sameContentProducesSameHash` -- deterministic
+    - `differentContentProducesDifferentHash`
+    - `emptyStringProducesValidHash` -- edge case: empty string has a known SHA-256
+
+    **GREEN phase: Implement to pass tests.**
+
+    **REFACTOR: Clean up if needed.**
+  </action>
+  <verify>
+    `./gradlew test --tests "dev.alexandria.crawl.ContentHasherTest"` passes. All 4 tests green.
+  </verify>
+  <done>ContentHasher.sha256() produces deterministic SHA-256 hex strings from content, verified against known test vectors.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `./quality.sh test` passes with all new tests green
+- CrawlScope stores scope config with immutable pattern lists
+- UrlScopeFilter.isAllowed correctly applies glob patterns on URL paths
+- ContentHasher.sha256 produces correct SHA-256 hex hashes
+- All classes follow existing static utility patterns (private constructor, Javadoc)
+</verification>
+
+<success_criteria>
+- All ~12 new unit tests pass
+- UrlScopeFilter handles all edge cases: external URLs, empty scope, block priority, malformed URLs
+- ContentHasher matches known SHA-256 test vectors
+- No regressions in existing test suite
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/07-crawl-operations/07-01-SUMMARY.md`
+</output>

--- a/.planning/phases/07-crawl-operations/07-01-SUMMARY.md
+++ b/.planning/phases/07-crawl-operations/07-01-SUMMARY.md
@@ -1,0 +1,112 @@
+---
+phase: 07-crawl-operations
+plan: 01
+subsystem: crawl
+tags: [url-filtering, glob-patterns, sha256, content-hashing, scope-control]
+
+# Dependency graph
+requires:
+  - phase: 03-web-crawling
+    provides: "UrlNormalizer static utility (isSameSite used by UrlScopeFilter)"
+provides:
+  - "CrawlScope record for immutable scope configuration"
+  - "UrlScopeFilter static utility for URL filtering by glob patterns"
+  - "ContentHasher static utility for SHA-256 content hashing"
+affects: [07-crawl-operations, ingestion]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [java.nio.file.PathMatcher glob matching on URL paths, HexFormat for hash formatting]
+
+key-files:
+  created:
+    - src/main/java/dev/alexandria/crawl/CrawlScope.java
+    - src/main/java/dev/alexandria/crawl/UrlScopeFilter.java
+    - src/main/java/dev/alexandria/crawl/ContentHasher.java
+    - src/test/java/dev/alexandria/crawl/CrawlScopeTest.java
+    - src/test/java/dev/alexandria/crawl/UrlScopeFilterTest.java
+    - src/test/java/dev/alexandria/crawl/ContentHasherTest.java
+  modified: []
+
+key-decisions:
+  - "PathMatcher glob on URL paths: use java.nio.file.FileSystems.getDefault().getPathMatcher for glob pattern matching against URL path segments"
+  - "Block patterns take priority: block patterns are checked before allow patterns, matching the user decision from plan"
+
+patterns-established:
+  - "CrawlScope record pattern: null-safe compact constructor with List.copyOf, static withDefaults factory"
+  - "Static utility pattern: private constructor, pure static methods (matches UrlNormalizer)"
+
+requirements-completed: [CRWL-03, CRWL-06]
+
+# Metrics
+duration: 5min
+completed: 2026-02-20
+---
+
+# Phase 7 Plan 01: Crawl Scope Utilities Summary
+
+**CrawlScope record, UrlScopeFilter with glob pattern matching, and ContentHasher SHA-256 utility for scope-limited crawling and change detection**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-02-20T09:30:56Z
+- **Completed:** 2026-02-20T09:36:05Z
+- **Tasks:** 2
+- **Files modified:** 6
+
+## Accomplishments
+- CrawlScope record with null-safe defensive copies and withDefaults factory
+- UrlScopeFilter correctly filters URLs by glob patterns with block-takes-priority semantics
+- ContentHasher produces deterministic SHA-256 hex strings verified against known test vectors
+- 15 new unit tests covering all edge cases (malformed URLs, empty scope, pattern priority)
+
+## Task Commits
+
+Each task was committed atomically (TDD: RED then GREEN):
+
+1. **Task 1: TDD CrawlScope record and UrlScopeFilter utility**
+   - `f011a17` (test) - Add failing tests for CrawlScope and UrlScopeFilter
+   - `088ea8c` (feat) - Implement CrawlScope record and UrlScopeFilter utility
+
+2. **Task 2: TDD ContentHasher utility**
+   - `6a76037` (test) - Add failing tests for ContentHasher
+   - `fd04e50` (feat) - Implement ContentHasher SHA-256 utility
+
+## Files Created/Modified
+- `src/main/java/dev/alexandria/crawl/CrawlScope.java` - Immutable scope config record (allow/block patterns, maxDepth, maxPages)
+- `src/main/java/dev/alexandria/crawl/UrlScopeFilter.java` - Static URL filtering utility with glob patterns via PathMatcher
+- `src/main/java/dev/alexandria/crawl/ContentHasher.java` - Static SHA-256 content hashing utility
+- `src/test/java/dev/alexandria/crawl/CrawlScopeTest.java` - 3 tests: null safety, defensive copy, factory method
+- `src/test/java/dev/alexandria/crawl/UrlScopeFilterTest.java` - 8 tests: external reject, allow/block patterns, edge cases
+- `src/test/java/dev/alexandria/crawl/ContentHasherTest.java` - 4 tests: known vector, determinism, uniqueness, empty string
+
+## Decisions Made
+- Used java.nio.file.PathMatcher for glob pattern matching on URL paths (as specified in plan)
+- Block patterns checked before allow patterns per user decision
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- CrawlScope, UrlScopeFilter, and ContentHasher are ready for use by CrawlService scope-limited crawling (07-02+)
+- UrlScopeFilter depends on UrlNormalizer.isSameSite (existing from Phase 3)
+- ContentHasher ready for incremental change detection in crawl pipeline
+
+## Self-Check: PASSED
+
+- All 7 files verified present on disk
+- All 4 commits verified in git history (f011a17, 088ea8c, 6a76037, fd04e50)
+- 180 tests pass (15 new + 165 existing), 0 failures
+
+---
+*Phase: 07-crawl-operations*
+*Completed: 2026-02-20*

--- a/.planning/phases/07-crawl-operations/07-02-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-02-PLAN.md
@@ -1,0 +1,143 @@
+---
+phase: 07-crawl-operations
+plan: 02
+type: tdd
+wave: 1
+depends_on: []
+files_modified:
+  - src/main/java/dev/alexandria/crawl/LlmsTxtParser.java
+  - src/test/java/dev/alexandria/crawl/LlmsTxtParserTest.java
+autonomous: true
+requirements:
+  - CRWL-11
+
+must_haves:
+  truths:
+    - "LlmsTxtParser extracts URLs from Markdown-link lists in llms.txt format"
+    - "LlmsTxtParser handles both llms.txt (URL lists) and llms-full.txt (raw content) inputs"
+    - "Parser gracefully handles empty, malformed, or unexpected content"
+  artifacts:
+    - path: "src/main/java/dev/alexandria/crawl/LlmsTxtParser.java"
+      provides: "llms.txt/llms-full.txt parser for URL extraction"
+      contains: "parseUrls"
+    - path: "src/test/java/dev/alexandria/crawl/LlmsTxtParserTest.java"
+      provides: "Unit tests for llms.txt parsing"
+      min_lines: 50
+  key_links:
+    - from: "src/main/java/dev/alexandria/crawl/LlmsTxtParser.java"
+      to: "llms.txt format"
+      via: "Regex extraction of markdown links"
+      pattern: "Pattern\\.compile"
+---
+
+<objective>
+TDD-develop the LlmsTxtParser utility for parsing llms.txt and llms-full.txt files, extracting URLs from Markdown-format link lists.
+
+Purpose: Enables the llms.txt discovery mechanism (CRWL-11) where documentation sites expose a machine-readable list of their content pages. The parser extracts URLs from the standard llms.txt Markdown format.
+Output: LlmsTxtParser class with comprehensive test suite covering the llms.txt specification format.
+</objective>
+
+<execution_context>
+@./.claude/get-shit-done/workflows/execute-plan.md
+@./.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/07-crawl-operations/07-RESEARCH.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: TDD LlmsTxtParser for URL extraction from llms.txt format</name>
+  <files>
+    src/main/java/dev/alexandria/crawl/LlmsTxtParser.java
+    src/test/java/dev/alexandria/crawl/LlmsTxtParserTest.java
+  </files>
+  <action>
+    **RED phase: Write tests first.**
+
+    **LlmsTxtParser** (`crawl/LlmsTxtParser.java`):
+    - Static utility class (private constructor), same pattern as UrlNormalizer and ContentHasher
+    - `public static List<String> parseUrls(String llmsTxtContent)`:
+      - Parses line-by-line, extracting URLs from Markdown link syntax: `- [Title](URL)` or `- [Title](URL): description`
+      - Also supports `[Title](URL)` without leading dash (some llms.txt variants)
+      - Returns list of extracted URL strings
+      - Ignores header lines (lines starting with `#`), blank lines, blockquote lines (starting with `>`)
+      - Uses regex: `Pattern.compile("\\[([^\\]]+)\\]\\(([^)]+)\\)")` to find markdown links
+    - `public static boolean isLlmsTxtContent(String content)`:
+      - Quick heuristic check: returns true if content contains at least one markdown link and starts with `#` header
+      - Used to distinguish llms-full.txt (which is raw Markdown content) from llms.txt (which is a link index)
+    - `public static LlmsTxtResult parse(String content)`:
+      - Returns a record with `List<String> urls` and `String rawContent` (the original content)
+      - If content looks like llms.txt (link index): extract URLs, rawContent is empty
+      - If content looks like llms-full.txt (Markdown docs): urls extracted from any inline links, rawContent is the full content for direct ingestion
+
+    **LlmsTxtResult record** (nested in LlmsTxtParser or separate file):
+    - `record LlmsTxtResult(List<String> urls, String rawContent, boolean isFullContent)`
+    - `isFullContent` = true when content is llms-full.txt (large Markdown for direct ingestion)
+
+    Tests for LlmsTxtParser (`LlmsTxtParserTest`):
+    - `parseUrlsExtractsLinksFromStandardFormat` -- standard `- [Title](URL)` format
+    - `parseUrlsHandlesLinksWithDescriptions` -- `- [Title](URL): some description`
+    - `parseUrlsIgnoresHeadersAndBlankLines` -- `# Header` and empty lines skipped
+    - `parseUrlsIgnoresBlockquotes` -- `> summary text` skipped
+    - `parseUrlsHandlesLinksWithoutDash` -- `[Title](URL)` without leading dash
+    - `parseUrlsReturnsEmptyForNoLinks` -- plain text with no markdown links
+    - `parseUrlsReturnsEmptyForNullOrEmpty` -- null and empty string edge cases
+    - `parseUrlsExtractsMultipleSections` -- H2 sections with links in each
+    - `isLlmsTxtContentDetectsLinkIndex` -- content with header + links returns true
+    - `isLlmsTxtContentRejectsPlainMarkdown` -- long prose content returns false
+    - `parseDistinguishesLlmsTxtFromLlmsFullTxt` -- llms.txt returns urls with empty rawContent, llms-full.txt returns urls with rawContent
+
+    Example test input (llms.txt format):
+    ```
+    # Spring Boot Documentation
+
+    > Spring Boot reference documentation
+
+    ## Getting Started
+
+    - [Quick Start](https://docs.spring.io/boot/quick-start): How to get started
+    - [Installation](https://docs.spring.io/boot/install)
+
+    ## Reference
+
+    - [Configuration](https://docs.spring.io/boot/config)
+    - [Actuator](https://docs.spring.io/boot/actuator): Production features
+    ```
+
+    Expected: 4 URLs extracted.
+
+    **GREEN phase: Implement to pass tests.**
+
+    **REFACTOR: Clean up if needed.**
+  </action>
+  <verify>
+    `./gradlew test --tests "dev.alexandria.crawl.LlmsTxtParserTest"` passes. All ~11 tests green.
+  </verify>
+  <done>LlmsTxtParser correctly parses llms.txt format, extracts URLs from Markdown links, distinguishes llms.txt (link index) from llms-full.txt (raw content), and handles all edge cases gracefully.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `./quality.sh test` passes with all new tests green
+- LlmsTxtParser.parseUrls extracts URLs from standard llms.txt format
+- Parser handles edge cases: missing dashes, descriptions after URLs, headers, blockquotes, empty content
+- LlmsTxtResult correctly flags llms-full.txt content for direct ingestion
+</verification>
+
+<success_criteria>
+- All ~11 new unit tests pass
+- URL extraction handles all variations of the llms.txt format
+- Distinction between llms.txt and llms-full.txt works reliably
+- No regressions in existing test suite
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/07-crawl-operations/07-02-SUMMARY.md`
+</output>

--- a/.planning/phases/07-crawl-operations/07-02-SUMMARY.md
+++ b/.planning/phases/07-crawl-operations/07-02-SUMMARY.md
@@ -1,0 +1,108 @@
+---
+phase: 07-crawl-operations
+plan: 02
+subsystem: crawl
+tags: [llms-txt, url-extraction, markdown-parsing, regex]
+
+# Dependency graph
+requires:
+  - phase: 03-web-crawling
+    provides: "crawl package structure, UrlNormalizer static utility pattern"
+provides:
+  - "LlmsTxtParser static utility for llms.txt/llms-full.txt parsing"
+  - "LlmsTxtResult record for typed parse results"
+  - "URL extraction from markdown link syntax"
+  - "Content classification heuristic (link index vs full content)"
+affects: [07-crawl-operations, crawl, ingestion]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [static-utility-with-regex, record-as-result-type, link-index-heuristic]
+
+key-files:
+  created:
+    - src/main/java/dev/alexandria/crawl/LlmsTxtParser.java
+    - src/test/java/dev/alexandria/crawl/LlmsTxtParserTest.java
+  modified: []
+
+key-decisions:
+  - "Link index threshold at 0.3 ratio for isLlmsTxtContent heuristic"
+  - "Regex-based parsing: Pattern [text](url) handles both dash-prefixed and bare links"
+  - "LlmsTxtResult as nested record in LlmsTxtParser (not separate file)"
+
+patterns-established:
+  - "Static utility with nested result record: LlmsTxtParser.parse() returns LlmsTxtResult"
+  - "Content classification heuristic: ratio of link lines to content lines distinguishes file types"
+
+requirements-completed: [CRWL-11]
+
+# Metrics
+duration: 5min
+completed: 2026-02-20
+---
+
+# Phase 7 Plan 02: LlmsTxtParser Summary
+
+**Static utility parsing llms.txt markdown link format with heuristic to distinguish link index from full content**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-02-20T09:30:59Z
+- **Completed:** 2026-02-20T09:36:10Z
+- **Tasks:** 1 (TDD: RED + GREEN)
+- **Files modified:** 2
+
+## Accomplishments
+- LlmsTxtParser extracts URLs from standard llms.txt markdown link format (with/without dashes, with/without descriptions)
+- Content classification heuristic distinguishes llms.txt (link index) from llms-full.txt (raw content)
+- 11 comprehensive unit tests covering all edge cases (null, empty, no links, blockquotes, multiple sections)
+- Follows established static utility pattern (same as UrlNormalizer, ContentHasher)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1 RED: TDD failing tests** - `cba21d0` (test)
+2. **Task 1 GREEN: LlmsTxtParser implementation** - `b44494b` (feat)
+
+_TDD task: RED (failing tests) then GREEN (passing implementation). No REFACTOR needed._
+
+## Files Created/Modified
+- `src/main/java/dev/alexandria/crawl/LlmsTxtParser.java` - Static utility for llms.txt parsing: parseUrls(), isLlmsTxtContent(), parse() methods with nested LlmsTxtResult record
+- `src/test/java/dev/alexandria/crawl/LlmsTxtParserTest.java` - 11 unit tests covering standard format, descriptions, headers, blockquotes, bare links, edge cases, and content classification
+
+## Decisions Made
+- Link index threshold at 0.3: content with >= 30% of non-blank, non-header lines containing markdown links is classified as llms.txt (link index). This correctly classifies the test cases (llms.txt has ~100% link lines, llms-full.txt has < 30%)
+- Regex pattern `\[([^\]]+)\]\(([^)]+)\)` extracts markdown links from any position on a line, supporting both `- [Title](URL)` and `[Title](URL)` variants
+- LlmsTxtResult as nested record in LlmsTxtParser rather than separate file, keeping the API self-contained
+- parseUrls skips headers (#), blockquotes (>), and blank lines per the llms.txt specification
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- LlmsTxtParser ready for integration into PageDiscoveryService as highest-priority URL discovery strategy
+- parse() method provides the classification needed for hybrid llms-full.txt ingestion (rawContent for direct chunking, urls for crawl gap-filling)
+
+## Self-Check: PASSED
+
+- [x] LlmsTxtParser.java exists (159 lines)
+- [x] LlmsTxtParserTest.java exists (251 lines, exceeds 50-line minimum)
+- [x] Commit cba21d0 exists (RED phase)
+- [x] Commit b44494b exists (GREEN phase)
+- [x] parseUrls method present
+- [x] Pattern.compile used for regex
+- [x] 142 total tests pass (BUILD SUCCESSFUL), 0 failures
+
+---
+*Phase: 07-crawl-operations*
+*Completed: 2026-02-20*

--- a/.planning/phases/07-crawl-operations/07-03-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-03-PLAN.md
@@ -15,6 +15,7 @@ files_modified:
   - src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
   - src/test/java/dev/alexandria/crawl/CrawlProgressTrackerTest.java
   - src/test/java/dev/alexandria/crawl/PageDiscoveryServiceTest.java
+  - src/test/java/dev/alexandria/crawl/CrawlServiceTest.java
 autonomous: true
 requirements:
   - CRWL-03
@@ -41,6 +42,9 @@ must_haves:
     - path: "src/main/java/dev/alexandria/crawl/CrawlProgress.java"
       provides: "Immutable crawl progress snapshot record"
       contains: "record CrawlProgress"
+    - path: "src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java"
+      provides: "Extended repository with source-level query methods for incremental crawling"
+      contains: "findAllBySourceId"
     - path: "src/main/java/dev/alexandria/crawl/PageDiscoveryService.java"
       provides: "Updated discovery with llms.txt priority cascade"
       contains: "llmsTxt"
@@ -154,6 +158,7 @@ Output: V2 migration, updated Source entity, extended repository, progress track
     src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
     src/test/java/dev/alexandria/crawl/CrawlProgressTrackerTest.java
     src/test/java/dev/alexandria/crawl/PageDiscoveryServiceTest.java
+    src/test/java/dev/alexandria/crawl/CrawlServiceTest.java
   </files>
   <action>
     **CrawlProgress record** (`crawl/CrawlProgress.java`):
@@ -224,6 +229,9 @@ Output: V2 migration, updated Source entity, extended repository, progress track
     - Add `noLlmsTxtNoSitemapFallsToLinkCrawl` -- both 404, link crawl returned
 
     Inject `RestClient.Builder` into PageDiscoveryService constructor. Follow the same pattern as SitemapParser: `restClientBuilder.build()` then `.get().uri(...).retrieve().body(String.class)` with try-catch for 404/errors.
+
+    **IMPORTANT: Update existing CrawlServiceTest.java for new DiscoveryResult shape**:
+    The `DiscoveryResult` record changes from `DiscoveryResult(List<String> urls, DiscoveryMethod method)` to `DiscoveryResult(List<String> urls, DiscoveryMethod method, String llmsFullContent)`. CrawlServiceTest.java has 10+ existing calls using the 2-arg constructor. Update ALL existing `new PageDiscoveryService.DiscoveryResult(urls, method)` calls to `new PageDiscoveryService.DiscoveryResult(urls, method, null)` to prevent compile errors. This is a mechanical find-and-replace across the test file.
   </action>
   <verify>
     `./quality.sh test` passes with all new and updated tests green. Run `./gradlew test --tests "dev.alexandria.crawl.CrawlProgressTrackerTest" --tests "dev.alexandria.crawl.PageDiscoveryServiceTest"` specifically.

--- a/.planning/phases/07-crawl-operations/07-03-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-03-PLAN.md
@@ -1,0 +1,256 @@
+---
+phase: 07-crawl-operations
+plan: 03
+type: execute
+wave: 2
+depends_on:
+  - "07-01"
+  - "07-02"
+files_modified:
+  - src/main/resources/db/migration/V2__source_scope_columns.sql
+  - src/main/java/dev/alexandria/source/Source.java
+  - src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java
+  - src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java
+  - src/main/java/dev/alexandria/crawl/CrawlProgress.java
+  - src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
+  - src/test/java/dev/alexandria/crawl/CrawlProgressTrackerTest.java
+  - src/test/java/dev/alexandria/crawl/PageDiscoveryServiceTest.java
+autonomous: true
+requirements:
+  - CRWL-03
+  - CRWL-06
+  - CRWL-09
+  - CRWL-11
+
+must_haves:
+  truths:
+    - "Source entity stores scope config (allow patterns, block patterns, max depth, max pages) persisted via Flyway migration"
+    - "IngestionStateRepository supports querying all states for a source and deleting orphaned pages"
+    - "CrawlProgressTracker provides thread-safe in-memory progress tracking for active crawls"
+    - "PageDiscoveryService tries llms.txt first, then sitemap.xml, then link crawl"
+  artifacts:
+    - path: "src/main/resources/db/migration/V2__source_scope_columns.sql"
+      provides: "Schema migration for scope columns on sources table"
+      contains: "ALTER TABLE sources"
+    - path: "src/main/java/dev/alexandria/source/Source.java"
+      provides: "Source entity with scope config fields"
+      contains: "allowPatterns"
+    - path: "src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java"
+      provides: "Thread-safe in-memory crawl progress tracking"
+      contains: "ConcurrentHashMap"
+    - path: "src/main/java/dev/alexandria/crawl/CrawlProgress.java"
+      provides: "Immutable crawl progress snapshot record"
+      contains: "record CrawlProgress"
+    - path: "src/main/java/dev/alexandria/crawl/PageDiscoveryService.java"
+      provides: "Updated discovery with llms.txt priority cascade"
+      contains: "llmsTxt"
+  key_links:
+    - from: "src/main/java/dev/alexandria/source/Source.java"
+      to: "src/main/resources/db/migration/V2__source_scope_columns.sql"
+      via: "JPA entity fields matching Flyway columns"
+      pattern: "allow_patterns|block_patterns|max_depth|max_pages"
+    - from: "src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java"
+      to: "src/main/java/dev/alexandria/crawl/CrawlProgress.java"
+      via: "Tracker stores/updates CrawlProgress records by source ID"
+      pattern: "ConcurrentHashMap.*CrawlProgress"
+    - from: "src/main/java/dev/alexandria/crawl/PageDiscoveryService.java"
+      to: "src/main/java/dev/alexandria/crawl/LlmsTxtParser.java"
+      via: "PageDiscoveryService calls LlmsTxtParser.parseUrls for URL extraction"
+      pattern: "LlmsTxtParser"
+---
+
+<objective>
+Build the infrastructure layer for Phase 7: database schema extension, Source entity scope fields, IngestionStateRepository query extensions, CrawlProgressTracker for real-time status, and PageDiscoveryService llms.txt cascade.
+
+Purpose: Provides the data layer and tracking infrastructure that the crawl orchestrator (Plan 04) and MCP tools (Plan 05) will build upon. Schema changes must be in place before any code uses the new columns.
+Output: V2 migration, updated Source entity, extended repository, progress tracker, and discovery cascade.
+</objective>
+
+<execution_context>
+@./.claude/get-shit-done/workflows/execute-plan.md
+@./.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/07-crawl-operations/07-RESEARCH.md
+@src/main/resources/db/migration/V1__initial_schema.sql
+@src/main/java/dev/alexandria/source/Source.java
+@src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java
+@src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
+@src/main/java/dev/alexandria/crawl/SitemapParser.java
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: V2 Flyway migration, Source entity scope fields, and IngestionStateRepository extensions</name>
+  <files>
+    src/main/resources/db/migration/V2__source_scope_columns.sql
+    src/main/java/dev/alexandria/source/Source.java
+    src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java
+  </files>
+  <action>
+    **V2 Flyway migration** (`V2__source_scope_columns.sql`):
+    Add scope configuration columns to sources table:
+    ```sql
+    ALTER TABLE sources ADD COLUMN allow_patterns TEXT[];
+    ALTER TABLE sources ADD COLUMN block_patterns TEXT[];
+    ALTER TABLE sources ADD COLUMN max_depth INTEGER;
+    ALTER TABLE sources ADD COLUMN max_pages INTEGER DEFAULT 500;
+    ALTER TABLE sources ADD COLUMN llms_txt_url TEXT;
+    ```
+    Use PostgreSQL native TEXT[] array type for pattern lists (JPA maps these via `@Column(columnDefinition = "text[]")` with `String[]` or use a converter). Default max_pages to 500 (reasonable safety limit). max_depth NULL = unlimited (per user decision). llms_txt_url allows manual llms.txt URL override.
+
+    **Source entity updates** (`source/Source.java`):
+    Add new fields with JPA column mappings:
+    - `String[] allowPatterns` with `@Column(name = "allow_patterns", columnDefinition = "text[]")` -- NOTE: Hibernate does not natively map text[], so use `@JdbcTypeCode(SqlTypes.ARRAY)` from `org.hibernate.annotations.JdbcTypeCode` and `org.hibernate.type.SqlTypes`. Alternatively, store as comma-separated TEXT and parse in Java. **Recommendation**: use simple TEXT columns (`allow_patterns_csv TEXT`, `block_patterns_csv TEXT`) storing comma-separated glob patterns. This avoids Hibernate array type complexity. Update migration accordingly if choosing this approach.
+    - Actually, given the complexity of PostgreSQL array types with Hibernate and this project's pragmatic architecture, use **JSONB column** for scope config: `scope_config JSONB` storing `{"allow": [...], "block": [...], "maxDepth": N, "maxPages": N, "llmsTxtUrl": "..."}`. But this also adds complexity.
+    - **Simplest approach per project conventions**: individual TEXT columns for each, with patterns stored as JSON arrays (`TEXT` column containing `["\/docs\/**", "\/api\/**"]`). Use Jackson ObjectMapper to serialize/deserialize in getter/setter. Actually the simplest: just use individual columns with patterns as comma-separated strings.
+    - **FINAL DECISION**: Use individual nullable columns. `allow_patterns TEXT` (comma-separated glob patterns), `block_patterns TEXT` (comma-separated glob patterns), `max_depth INTEGER`, `max_pages INTEGER DEFAULT 500`, `llms_txt_url TEXT`. Parse comma-separated patterns in a helper method `getBlockPatternList()` / `getAllowPatternList()` that returns `List<String>`. This is the simplest JPA mapping and avoids any Hibernate type adapter complexity.
+
+    Update migration SQL:
+    ```sql
+    ALTER TABLE sources ADD COLUMN allow_patterns TEXT;
+    ALTER TABLE sources ADD COLUMN block_patterns TEXT;
+    ALTER TABLE sources ADD COLUMN max_depth INTEGER;
+    ALTER TABLE sources ADD COLUMN max_pages INTEGER DEFAULT 500;
+    ALTER TABLE sources ADD COLUMN llms_txt_url TEXT;
+    ```
+
+    Add to Source entity:
+    - `private String allowPatterns;` with `@Column(name = "allow_patterns")`
+    - `private String blockPatterns;` with `@Column(name = "block_patterns")`
+    - `private Integer maxDepth;` with `@Column(name = "max_depth")`
+    - `private Integer maxPages;` with `@Column(name = "max_pages")`
+    - `private String llmsTxtUrl;` with `@Column(name = "llms_txt_url")`
+    - Helper methods: `getAllowPatternList()` returns `List<String>` by splitting on `,` (trimmed), empty string = empty list
+    - Helper methods: `getBlockPatternList()` returns `List<String>` same pattern
+    - `toCrawlScope()` method that builds a `CrawlScope` record from the entity fields (convenience method)
+    - Standard getters and setters for all new fields
+    - Update `Source(String url, String name)` constructor to default maxPages to 500
+
+    **IngestionStateRepository extensions**:
+    Add query methods:
+    - `List<IngestionState> findAllBySourceId(UUID sourceId)` -- for deleted page detection (get all indexed pages)
+    - `void deleteAllBySourceId(UUID sourceId)` -- for full recrawl reset
+    - `void deleteAllBySourceIdAndPageUrlNotIn(UUID sourceId, Collection<String> pageUrls)` -- for orphaned page cleanup. Spring Data derives this from method name.
+
+    Also update the test fixture builder `SourceBuilder` if it exists, adding builder methods for new fields.
+  </action>
+  <verify>
+    `./quality.sh test` passes (migration validated at integration test time). Check Source entity compiles with new fields. Verify IngestionStateRepository method signatures compile.
+  </verify>
+  <done>V2 migration adds scope columns to sources table. Source entity has scope config fields with helper methods. IngestionStateRepository supports queries needed for incremental crawling (all by source, delete orphans).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: CrawlProgressTracker and PageDiscoveryService llms.txt cascade</name>
+  <files>
+    src/main/java/dev/alexandria/crawl/CrawlProgress.java
+    src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java
+    src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
+    src/test/java/dev/alexandria/crawl/CrawlProgressTrackerTest.java
+    src/test/java/dev/alexandria/crawl/PageDiscoveryServiceTest.java
+  </files>
+  <action>
+    **CrawlProgress record** (`crawl/CrawlProgress.java`):
+    ```java
+    public record CrawlProgress(
+        UUID sourceId,
+        SourceStatus status,
+        int pagesCrawled,
+        int pagesSkipped,       // unchanged content hash
+        int pagesTotal,         // discovered URLs count (may grow during BFS)
+        int errors,
+        List<String> errorUrls,
+        List<String> filteredUrls,  // URLs excluded by scope
+        Instant startedAt
+    ) {
+        public CrawlProgress {
+            errorUrls = errorUrls == null ? List.of() : List.copyOf(errorUrls);
+            filteredUrls = filteredUrls == null ? List.of() : List.copyOf(filteredUrls);
+        }
+    }
+    ```
+
+    **CrawlProgressTracker** (`crawl/CrawlProgressTracker.java`):
+    - Spring `@Component` (singleton)
+    - Internal `ConcurrentHashMap<UUID, CrawlProgress>` for active crawls
+    - Methods:
+      - `startCrawl(UUID sourceId, int initialTotal)` -- creates initial CrawlProgress with CRAWLING status, 0 crawled/skipped/errors
+      - `recordPageCrawled(UUID sourceId)` -- increments pagesCrawled
+      - `recordPageSkipped(UUID sourceId)` -- increments pagesSkipped (unchanged hash)
+      - `recordError(UUID sourceId, String url)` -- increments errors, adds to errorUrls
+      - `recordFiltered(UUID sourceId, String url)` -- adds to filteredUrls
+      - `updateTotal(UUID sourceId, int total)` -- updates pagesTotal (BFS discovery grows over time)
+      - `completeCrawl(UUID sourceId)` -- sets status to INDEXED
+      - `failCrawl(UUID sourceId)` -- sets status to ERROR
+      - `getProgress(UUID sourceId)` -- returns `Optional<CrawlProgress>`
+      - `removeCrawl(UUID sourceId)` -- cleanup after completion
+    - Thread safety: since CrawlProgress is immutable, each update reads current, creates new record with updated fields, puts back. Use `ConcurrentHashMap.compute()` for atomic read-modify-write.
+    - Javadoc on class and public methods
+
+    **CrawlProgressTracker tests** (`CrawlProgressTrackerTest`):
+    - `startCrawlCreatesInitialProgress` -- verify initial state
+    - `recordPageCrawledIncrementsCount`
+    - `recordPageSkippedIncrementsCount`
+    - `recordErrorAddsUrlToList`
+    - `recordFilteredAddsUrlToList`
+    - `completeCrawlSetsIndexedStatus`
+    - `getProgressReturnsEmptyForUnknownSource`
+    - `removeCrawlCleansUpMemory`
+
+    **PageDiscoveryService update**:
+    - Add `RestClient.Builder` dependency for HTTP fetching of llms.txt (same pattern as SitemapParser)
+    - Update `discoverUrls(String rootUrl)` to implement the priority cascade:
+      1. Try `{baseUrl}/llms.txt` via HTTP GET. If found, parse with `LlmsTxtParser.parseUrls()`. If URLs extracted, return with `DiscoveryMethod.LLMS_TXT`.
+      2. Try sitemap.xml (existing behavior)
+      3. Fall back to LINK_CRAWL (existing behavior)
+    - Each level supplements the previous (per user decision): if llms.txt provides URLs AND sitemap provides additional URLs, merge them (union). In practice, return llms.txt URLs as primary set; the CrawlService will discover additional pages via sitemap/links during crawl.
+    - Add `LLMS_TXT` to `DiscoveryMethod` enum
+    - Also try `{baseUrl}/llms-full.txt`: if found, parse and return with `DiscoveryMethod.LLMS_FULL_TXT`. The CrawlService (Plan 04) will handle ingesting the full content.
+    - New `DiscoveryResult` fields: add `String llmsFullContent` (null if not llms-full.txt, contains raw content for direct ingestion)
+    - Update `DiscoveryResult` record: `record DiscoveryResult(List<String> urls, DiscoveryMethod method, String llmsFullContent)`
+    - The `llmsFullContent` field is only populated when llms-full.txt is available, enabling hybrid ingestion
+
+    **PageDiscoveryService test updates** (`PageDiscoveryServiceTest`):
+    - Update existing tests for new DiscoveryResult shape (add null llmsFullContent)
+    - Add `llmsTxtFoundReturnsUrls` -- mock HTTP returning llms.txt content, verify URLs extracted
+    - Add `llmsFullTxtFoundReturnsContentAndUrls` -- mock HTTP returning llms-full.txt, verify rawContent populated
+    - Add `llmsTxtNotFoundFallsToSitemap` -- llms.txt 404, sitemap found
+    - Add `noLlmsTxtNoSitemapFallsToLinkCrawl` -- both 404, link crawl returned
+
+    Inject `RestClient.Builder` into PageDiscoveryService constructor. Follow the same pattern as SitemapParser: `restClientBuilder.build()` then `.get().uri(...).retrieve().body(String.class)` with try-catch for 404/errors.
+  </action>
+  <verify>
+    `./quality.sh test` passes with all new and updated tests green. Run `./gradlew test --tests "dev.alexandria.crawl.CrawlProgressTrackerTest" --tests "dev.alexandria.crawl.PageDiscoveryServiceTest"` specifically.
+  </verify>
+  <done>CrawlProgressTracker provides thread-safe in-memory progress tracking. PageDiscoveryService implements llms.txt > sitemap > link crawl discovery cascade. CrawlProgress record captures crawl state with error and filtered URL details.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `./quality.sh test` passes with no regressions
+- V2 migration applies cleanly (verified via integration tests if run)
+- Source entity has scope config fields that compile and map to DB columns
+- IngestionStateRepository has all query methods needed for incremental crawling
+- CrawlProgressTracker is thread-safe and all tests pass
+- PageDiscoveryService tries llms.txt before sitemap before link crawl
+</verification>
+
+<success_criteria>
+- V2 Flyway migration creates scope columns on sources table
+- Source.toCrawlScope() creates correct CrawlScope from entity fields
+- IngestionStateRepository has findAllBySourceId, deleteAllBySourceId, deleteAllBySourceIdAndPageUrlNotIn
+- CrawlProgressTracker all 8 tests pass
+- PageDiscoveryService discovery cascade verified with 4+ tests
+- No regressions in existing ~130 tests
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/07-crawl-operations/07-03-SUMMARY.md`
+</output>

--- a/.planning/phases/07-crawl-operations/07-03-SUMMARY.md
+++ b/.planning/phases/07-crawl-operations/07-03-SUMMARY.md
@@ -1,0 +1,141 @@
+---
+phase: 07-crawl-operations
+plan: 03
+subsystem: crawl, database
+tags: [flyway, jpa, concurrenthashmap, llms-txt, sitemap, restclient, scope-filtering]
+
+# Dependency graph
+requires:
+  - phase: 07-01
+    provides: "CrawlScope record and UrlScopeFilter for URL filtering"
+  - phase: 07-02
+    provides: "LlmsTxtParser for parsing llms.txt/llms-full.txt content"
+provides:
+  - "V2 Flyway migration adding scope columns to sources table"
+  - "Source entity with scope config fields and pattern parsing helpers"
+  - "CrawlScope.fromSource() factory method for building scope from Source"
+  - "IngestionStateRepository query extensions for incremental crawling"
+  - "CrawlProgressTracker for thread-safe in-memory crawl progress"
+  - "CrawlProgress immutable record with Status enum"
+  - "PageDiscoveryService llms.txt > sitemap > link crawl discovery cascade"
+  - "DiscoveryResult with llmsFullContent for hybrid ingestion"
+affects: [07-04, 07-05]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "ConcurrentHashMap.computeIfPresent for atomic read-modify-write on immutable records"
+    - "Answer-based URI routing in RestClient mock chains for multi-endpoint tests"
+    - "CrawlScope.fromSource() factory to avoid bidirectional package dependency"
+
+key-files:
+  created:
+    - src/main/resources/db/migration/V2__source_scope_columns.sql
+    - src/main/java/dev/alexandria/crawl/CrawlProgress.java
+    - src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java
+    - src/test/java/dev/alexandria/crawl/CrawlProgressTrackerTest.java
+  modified:
+    - src/main/java/dev/alexandria/source/Source.java
+    - src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java
+    - src/main/java/dev/alexandria/crawl/CrawlScope.java
+    - src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
+    - src/test/java/dev/alexandria/crawl/PageDiscoveryServiceTest.java
+    - src/test/java/dev/alexandria/crawl/CrawlServiceTest.java
+    - src/test/java/dev/alexandria/fixture/SourceBuilder.java
+
+key-decisions:
+  - "CrawlProgress uses own Status enum instead of SourceStatus to avoid crawl<->source package cycle"
+  - "CrawlScope.fromSource() factory method on CrawlScope instead of Source.toCrawlScope() to maintain unidirectional crawl->source dependency"
+  - "Comma-separated TEXT columns for allow/block patterns (simplest JPA mapping, no Hibernate array type complexity)"
+  - "Answer-based URI routing for PageDiscoveryService RestClient mock chain"
+
+patterns-established:
+  - "ConcurrentHashMap.computeIfPresent pattern: immutable records in concurrent map with atomic updates"
+  - "Factory method on consuming class (CrawlScope.fromSource) to prevent bidirectional package deps"
+
+requirements-completed: [CRWL-03, CRWL-06, CRWL-09, CRWL-11]
+
+# Metrics
+duration: 7min
+completed: 2026-02-20
+---
+
+# Phase 7 Plan 3: Infrastructure Layer Summary
+
+**V2 schema migration with Source scope fields, CrawlProgressTracker for thread-safe crawl tracking, and PageDiscoveryService llms.txt discovery cascade**
+
+## Performance
+
+- **Duration:** 7 min
+- **Started:** 2026-02-20T09:40:33Z
+- **Completed:** 2026-02-20T09:48:29Z
+- **Tasks:** 2
+- **Files modified:** 11
+
+## Accomplishments
+- V2 Flyway migration adds allow_patterns, block_patterns, max_depth, max_pages, llms_txt_url columns to sources table
+- Source entity extended with scope config fields, comma-separated pattern parsing, and CrawlScope.fromSource() factory
+- IngestionStateRepository extended with findAllBySourceId, deleteAllBySourceId, deleteAllBySourceIdAndPageUrlNotIn for incremental crawling
+- CrawlProgressTracker provides thread-safe in-memory progress tracking with ConcurrentHashMap atomic updates
+- PageDiscoveryService implements 4-level discovery cascade: llms-full.txt > llms.txt > sitemap.xml > link crawl
+- 13 new tests (9 CrawlProgressTracker + 4 PageDiscoveryService llms.txt) with 0 regressions (193 total)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: V2 migration, Source scope fields, IngestionStateRepository extensions** - `2782771` (feat)
+2. **Task 2: CrawlProgressTracker and PageDiscoveryService llms.txt cascade** - `b4547de` (feat)
+
+## Files Created/Modified
+- `src/main/resources/db/migration/V2__source_scope_columns.sql` - Schema migration for scope columns on sources table
+- `src/main/java/dev/alexandria/source/Source.java` - Scope config fields with comma-separated pattern parsing helpers
+- `src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java` - Extended with source-level query methods for incremental crawling
+- `src/main/java/dev/alexandria/crawl/CrawlScope.java` - Added fromSource() factory method
+- `src/main/java/dev/alexandria/crawl/CrawlProgress.java` - Immutable crawl progress snapshot record with Status enum
+- `src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java` - Thread-safe in-memory progress tracker using ConcurrentHashMap
+- `src/main/java/dev/alexandria/crawl/PageDiscoveryService.java` - llms.txt > sitemap > link crawl discovery cascade
+- `src/test/java/dev/alexandria/crawl/CrawlProgressTrackerTest.java` - 9 unit tests for progress tracker
+- `src/test/java/dev/alexandria/crawl/PageDiscoveryServiceTest.java` - Updated with 4 new llms.txt cascade tests
+- `src/test/java/dev/alexandria/crawl/CrawlServiceTest.java` - Updated 10 DiscoveryResult call sites for 3-arg constructor
+- `src/test/java/dev/alexandria/fixture/SourceBuilder.java` - Builder methods for all new scope fields
+
+## Decisions Made
+- **CrawlProgress.Status enum instead of SourceStatus**: CrawlProgress record needs a status field. Using SourceStatus would create a crawl->source dependency; combined with Source importing from crawl (for toCrawlScope), this would create a package cycle violating ArchUnit's no_package_cycles rule. Solution: dedicated CrawlProgress.Status enum (CRAWLING, COMPLETED, FAILED) in the crawl package.
+- **CrawlScope.fromSource() instead of Source.toCrawlScope()**: Plan specified Source.toCrawlScope() which would create source->crawl dependency. Moving to CrawlScope.fromSource() maintains unidirectional crawl->source flow and avoids the cycle.
+- **Comma-separated TEXT for patterns**: Plan deliberated between TEXT[], JSONB, and comma-separated TEXT. Chose simplest JPA mapping with helper methods for parsing.
+- **Answer-based URI routing in tests**: RestClient mock chain uses answer-based routing on uri() calls to route different URLs to different responses, avoiding wildcard capture issues with Mockito generics.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] CrawlProgress uses own Status enum instead of SourceStatus**
+- **Found during:** Task 2 (CrawlProgress record creation)
+- **Issue:** Plan specified `SourceStatus status` field in CrawlProgress. This would create crawl->source dependency. Combined with Source.toCrawlScope() creating source->crawl dependency, this would create a package cycle detected by ArchUnit.
+- **Fix:** Created CrawlProgress.Status enum (CRAWLING, COMPLETED, FAILED) within crawl package. Also moved toCrawlScope() to CrawlScope.fromSource() factory.
+- **Files modified:** CrawlProgress.java, CrawlScope.java, Source.java
+- **Verification:** `./quality.sh test` passes, ArchUnit cycle detection passes
+- **Committed in:** 2782771, b4547de
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking - package cycle prevention)
+**Impact on plan:** Necessary to maintain clean architecture. Same functionality, different location.
+
+## Issues Encountered
+- Mockito wildcard capture type mismatch with `RestClient.RequestHeadersUriSpec<?>`: resolved by using answer-based URI routing pattern instead of direct thenReturn() stubs
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Schema migration, scope config, progress tracking, and discovery cascade all ready for crawl orchestrator (Plan 04)
+- CrawlScope.fromSource() available for orchestrator to build scope from Source entity
+- CrawlProgressTracker ready for real-time progress tracking during orchestrated crawls
+- DiscoveryResult.llmsFullContent() enables hybrid ingestion in Plan 04
+
+---
+*Phase: 07-crawl-operations*
+*Completed: 2026-02-20*

--- a/.planning/phases/07-crawl-operations/07-04-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-04-PLAN.md
@@ -1,0 +1,233 @@
+---
+phase: 07-crawl-operations
+plan: 04
+type: execute
+wave: 3
+depends_on:
+  - "07-01"
+  - "07-02"
+  - "07-03"
+files_modified:
+  - src/main/java/dev/alexandria/crawl/CrawlService.java
+  - src/main/java/dev/alexandria/ingestion/IngestionService.java
+  - src/test/java/dev/alexandria/crawl/CrawlServiceTest.java
+  - src/test/java/dev/alexandria/ingestion/IngestionServiceTest.java
+autonomous: true
+requirements:
+  - CRWL-03
+  - CRWL-06
+  - CRWL-11
+
+must_haves:
+  truths:
+    - "CrawlService applies scope filtering (allow/block patterns, max depth) during BFS crawl"
+    - "CrawlService performs incremental crawl: skips pages with unchanged content hash, re-processes changed pages"
+    - "CrawlService detects and cleans up deleted pages post-crawl"
+    - "CrawlService handles llms-full.txt content via hybrid ingestion (ingest directly + fill gaps via crawl)"
+    - "CrawlService tracks progress via CrawlProgressTracker during crawl"
+  artifacts:
+    - path: "src/main/java/dev/alexandria/crawl/CrawlService.java"
+      provides: "Evolved crawl orchestrator with scope, incremental, progress, llms.txt support"
+      contains: "CrawlScope"
+    - path: "src/main/java/dev/alexandria/ingestion/IngestionService.java"
+      provides: "Ingestion with change detection and per-page deletion"
+      contains: "ContentHasher"
+    - path: "src/test/java/dev/alexandria/crawl/CrawlServiceTest.java"
+      provides: "Updated unit tests for crawl orchestrator"
+      min_lines: 80
+  key_links:
+    - from: "src/main/java/dev/alexandria/crawl/CrawlService.java"
+      to: "src/main/java/dev/alexandria/crawl/UrlScopeFilter.java"
+      via: "Scope filtering before crawling each URL"
+      pattern: "UrlScopeFilter\\.isAllowed"
+    - from: "src/main/java/dev/alexandria/crawl/CrawlService.java"
+      to: "src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java"
+      via: "Progress updates during crawl loop"
+      pattern: "progressTracker\\.record"
+    - from: "src/main/java/dev/alexandria/crawl/CrawlService.java"
+      to: "src/main/java/dev/alexandria/ingestion/IngestionService.java"
+      via: "Incremental ingest with hash-based change detection"
+      pattern: "ingestionService\\.ingestPageIncremental"
+    - from: "src/main/java/dev/alexandria/ingestion/IngestionService.java"
+      to: "src/main/java/dev/alexandria/crawl/ContentHasher.java"
+      via: "SHA-256 hash comparison for change detection"
+      pattern: "ContentHasher\\.sha256"
+---
+
+<objective>
+Evolve CrawlService and IngestionService to support scope-filtered crawling with depth tracking, incremental ingestion via content hash change detection, deleted page cleanup, llms-full.txt hybrid ingestion, and progress tracking.
+
+Purpose: This is the core orchestration plan connecting all utilities (Plan 01-03) into a working crawl system that respects scope limits, skips unchanged pages, and tracks progress. Addresses the main functional requirements for crawl operations.
+Output: Updated CrawlService with full scope/incremental/progress support. Updated IngestionService with hash-based change detection.
+</objective>
+
+<execution_context>
+@./.claude/get-shit-done/workflows/execute-plan.md
+@./.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/07-crawl-operations/07-RESEARCH.md
+@.planning/phases/07-crawl-operations/07-01-SUMMARY.md
+@.planning/phases/07-crawl-operations/07-02-SUMMARY.md
+@.planning/phases/07-crawl-operations/07-03-SUMMARY.md
+@src/main/java/dev/alexandria/crawl/CrawlService.java
+@src/main/java/dev/alexandria/ingestion/IngestionService.java
+@src/main/java/dev/alexandria/ingestion/IngestionState.java
+@src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java
+@src/main/java/dev/alexandria/crawl/CrawlScope.java
+@src/main/java/dev/alexandria/crawl/UrlScopeFilter.java
+@src/main/java/dev/alexandria/crawl/ContentHasher.java
+@src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java
+@src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Evolve CrawlService with scope filtering, depth tracking, progress, and llms-full.txt hybrid ingestion</name>
+  <files>
+    src/main/java/dev/alexandria/crawl/CrawlService.java
+    src/test/java/dev/alexandria/crawl/CrawlServiceTest.java
+  </files>
+  <action>
+    **Evolve CrawlService** to accept CrawlScope and sourceId, applying scope filtering and depth tracking during BFS crawl, with progress reporting and llms-full.txt hybrid support.
+
+    **New method signature** (replace or overload existing `crawlSite`):
+    ```java
+    public List<CrawlResult> crawlSite(UUID sourceId, String rootUrl, CrawlScope scope)
+    ```
+    - The old `crawlSite(String rootUrl, int maxPages)` should delegate to the new method, creating a default CrawlScope.
+
+    **Add new constructor dependencies**:
+    - `CrawlProgressTracker progressTracker` (from Plan 03)
+    - `IngestionService ingestionService` (for incremental ingestion during crawl -- see Task 2)
+    - `IngestionStateRepository ingestionStateRepository` (for change detection and orphan cleanup)
+    - `EmbeddingStore<TextSegment> embeddingStore` (for per-page chunk deletion)
+
+    **Depth tracking changes**:
+    - Replace `LinkedHashSet<String>` queue with `LinkedHashMap<String, Integer>` mapping URL to its discovery depth (or use a `Deque<QueueEntry>` where `record QueueEntry(String url, int depth)`)
+    - Seed URLs from discovery have depth 0
+    - Discovered links get parent depth + 1
+    - Before crawling a URL, check: if `scope.maxDepth() != null && depth > scope.maxDepth()`, skip (do not crawl, do not log as filtered)
+
+    **Scope filtering changes**:
+    - Before adding any URL to the queue (both seed and discovered links), check `UrlScopeFilter.isAllowed(url, rootUrl, scope)`
+    - If URL is filtered, log it and call `progressTracker.recordFiltered(sourceId, url)` (per user decision: filtered URLs logged, available in crawl_status)
+    - Apply scope filter to discovered links in `enqueueDiscoveredLinks`
+
+    **Progress tracking changes**:
+    - Call `progressTracker.startCrawl(sourceId, queue.size())` after seeding the queue
+    - After each page crawl: `progressTracker.recordPageCrawled(sourceId)` (or `recordPageSkipped` if hash unchanged, or `recordError`)
+    - When discovering new URLs that expand the queue: `progressTracker.updateTotal(sourceId, discoveredCount)`
+    - After crawl completes: `progressTracker.completeCrawl(sourceId)` (or `failCrawl` on exception)
+
+    **llms-full.txt hybrid ingestion**:
+    - After page discovery, check if `DiscoveryResult.llmsFullContent()` is non-null
+    - If present: ingest the llms-full.txt content directly via `ingestionService.ingestPage(llmsFullContent, rootUrl, Instant.now().toString())`
+    - Track which URLs from the llms.txt list are "covered" by llms-full.txt (the URLs from `discovery.urls()` when method is LLMS_FULL_TXT). These are marked as already ingested.
+    - During BFS crawl, skip pages whose URL is in the llms-full.txt covered set (they're already ingested)
+    - This implements the hybrid approach: llms-full.txt provides the primary content, crawling fills any gaps
+
+    **Deleted page cleanup** (post-crawl):
+    - After the crawl loop completes, invoke `cleanupDeletedPages(sourceId, crawledUrls)`:
+      1. `List<IngestionState> allStates = ingestionStateRepository.findAllBySourceId(sourceId)`
+      2. Find orphaned URLs: states whose pageUrl is not in crawledUrls set
+      3. For each orphaned URL: `embeddingStore.removeAll(metadataKey("source_url").isEqualTo(orphanUrl))`
+      4. Delete the orphaned IngestionState records: `ingestionStateRepository.deleteAllBySourceIdAndPageUrlNotIn(sourceId, crawledUrls)`
+    - Only run cleanup for incremental recrawls (not initial crawl where there are no prior states)
+
+    **Updated CrawlServiceTest**:
+    - Update existing tests for new constructor (mock new dependencies)
+    - `scopeFilterRejectsBlockedUrls` -- verify URLs matching block patterns are not crawled
+    - `scopeFilterAllowsMatchingUrls` -- verify only URLs matching allow patterns are crawled
+    - `maxDepthLimitsUrlDiscovery` -- verify URLs beyond maxDepth are not enqueued
+    - `progressTrackerUpdatedDuringCrawl` -- verify startCrawl, recordPageCrawled, completeCrawl called
+    - `llmsFullContentIngestedDirectly` -- verify llms-full.txt content ingested, covered URLs skipped
+    - Keep existing test behaviors (BFS, maxPages, link following, sitemap mode)
+  </action>
+  <verify>
+    `./quality.sh test` passes. All CrawlService tests pass including new scope/depth/progress tests. Run `./gradlew test --tests "dev.alexandria.crawl.CrawlServiceTest"`.
+  </verify>
+  <done>CrawlService applies scope filtering (block > allow priority), respects max depth, tracks progress via CrawlProgressTracker, handles llms-full.txt hybrid ingestion, and cleans up deleted pages post-crawl.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: IngestionService incremental ingestion with hash-based change detection</name>
+  <files>
+    src/main/java/dev/alexandria/ingestion/IngestionService.java
+    src/test/java/dev/alexandria/ingestion/IngestionServiceTest.java
+  </files>
+  <action>
+    **Add incremental ingestion method** to IngestionService:
+
+    Add constructor dependencies:
+    - `IngestionStateRepository ingestionStateRepository`
+    - `EmbeddingStore<TextSegment> embeddingStore` (already available for chunk deletion -- currently only used transitively via storeChunks; need direct reference for removeAll)
+
+    Wait -- IngestionService already has `embeddingStore` field. Good. Add `ingestionStateRepository`.
+
+    **New method**: `public IngestResult ingestPageIncremental(UUID sourceId, String url, String markdown)`
+
+    **IngestResult record** (nested or in `ingestion/` package):
+    ```java
+    public record IngestResult(int chunksStored, boolean skipped, boolean changed) {}
+    ```
+    - `skipped = true` means content hash unchanged, no processing done
+    - `changed = true` means new or changed content, re-chunked and re-embedded
+
+    **Implementation flow** (per research pattern):
+    1. Normalize URL via `UrlNormalizer.normalize(url)`
+    2. Compute hash: `String newHash = ContentHasher.sha256(markdown)`
+    3. Look up existing state: `ingestionStateRepository.findBySourceIdAndPageUrl(sourceId, normalizedUrl)`
+    4. **If existing hash matches**: return `IngestResult(0, true, false)` -- skip entirely
+    5. **If hash differs or no record**:
+       a. Delete old chunks: `embeddingStore.removeAll(metadataKey("source_url").isEqualTo(normalizedUrl))` (using `import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey`)
+       b. Chunk and embed: call existing `ingestPage(markdown, normalizedUrl, Instant.now().toString())` which returns chunk count
+       c. Update or create IngestionState:
+          - If existing: `existing.setContentHash(newHash); existing.setLastIngestedAt(Instant.now()); ingestionStateRepository.save(existing)`
+          - If new: `ingestionStateRepository.save(new IngestionState(sourceId, normalizedUrl, newHash))`
+       d. Return `IngestResult(chunkCount, false, true)`
+
+    **Keep existing methods** (`ingest(List<CrawlResult>)` and `ingestPage(...)`) unchanged for backward compatibility. The new `ingestPageIncremental` is used by the evolved CrawlService.
+
+    **Updated IngestionServiceTest**:
+    - Update existing tests for new constructor (mock ingestionStateRepository)
+    - `ingestPageIncrementalSkipsUnchangedContent` -- same hash returns skipped=true, no embedding/store calls
+    - `ingestPageIncrementalReprocessesChangedContent` -- different hash: deletes old chunks, re-chunks, re-embeds, updates state
+    - `ingestPageIncrementalCreatesNewStateForNewPage` -- no existing state: creates new IngestionState
+    - `ingestPageIncrementalDeletesOldChunksBeforeReingesting` -- verify removeAll called before addAll (ordering matters)
+    - Keep all existing test behaviors
+  </action>
+  <verify>
+    `./quality.sh test` passes. All IngestionService tests pass including new incremental tests. Run `./gradlew test --tests "dev.alexandria.ingestion.IngestionServiceTest"`.
+  </verify>
+  <done>IngestionService.ingestPageIncremental performs hash-based change detection: skips unchanged pages, deletes old chunks and re-ingests changed pages, and persists content hash state for future comparisons.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `./quality.sh test` passes with all new and existing tests green
+- CrawlService filters URLs by scope patterns during BFS crawl
+- CrawlService respects maxDepth during link discovery
+- CrawlService tracks progress and reports via CrawlProgressTracker
+- IngestionService skips unchanged pages and re-ingests changed ones
+- Deleted page cleanup removes orphaned chunks post-crawl
+- llms-full.txt content ingested directly, gaps filled by crawling
+</verification>
+
+<success_criteria>
+- CrawlService scope tests verify block > allow pattern priority
+- CrawlService depth tests verify maxDepth enforcement
+- IngestionService incremental tests verify skip/reprocess/new-page paths
+- Progress tracker integration verified in CrawlService tests
+- No regressions in existing ~130+ tests
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/07-crawl-operations/07-04-SUMMARY.md`
+</output>

--- a/.planning/phases/07-crawl-operations/07-04-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-04-PLAN.md
@@ -124,7 +124,11 @@ Output: Updated CrawlService with full scope/incremental/progress support. Updat
           - If new: `ingestionStateRepository.save(new IngestionState(sourceId, normalizedUrl, newHash))`
        d. Return `IngestResult(chunkCount, false, true)`
 
-    **Keep existing methods** (`ingest(List<CrawlResult>)` and `ingestPage(...)`) unchanged for backward compatibility. The new `ingestPageIncremental` is used by the evolved CrawlService (Task 2).
+    **Add clearIngestionState method**: `public void clearIngestionState(UUID sourceId)`
+    - Implementation: `ingestionStateRepository.deleteAllBySourceId(sourceId)`
+    - Used by McpToolService when a full recrawl is triggered (full=true flag). Placing this here keeps the repository boundary inside the ingestion service layer and avoids leaking IngestionStateRepository into adapter packages.
+
+    **Keep existing methods** (`ingest(List<CrawlResult>)` and `ingestPage(...)`) unchanged for backward compatibility. The new `ingestPageIncremental` and `clearIngestionState` are used by the evolved CrawlService (Task 2) and McpToolService (Plan 05) respectively.
 
     **Updated IngestionServiceTest**:
     - Update existing tests for new constructor (mock ingestionStateRepository)
@@ -132,6 +136,7 @@ Output: Updated CrawlService with full scope/incremental/progress support. Updat
     - `ingestPageIncrementalReprocessesChangedContent` -- different hash: deletes old chunks, re-chunks, re-embeds, updates state
     - `ingestPageIncrementalCreatesNewStateForNewPage` -- no existing state: creates new IngestionState
     - `ingestPageIncrementalDeletesOldChunksBeforeReingesting` -- verify removeAll called before addAll (ordering matters)
+    - `clearIngestionStateDelegatesDeleteToRepository` -- verify ingestionStateRepository.deleteAllBySourceId(sourceId) called
     - Keep all existing test behaviors
   </action>
   <verify>

--- a/.planning/phases/07-crawl-operations/07-04-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-04-PLAN.md
@@ -88,13 +88,66 @@ Output: Updated CrawlService with full scope/incremental/progress support. Updat
 <tasks>
 
 <task type="auto">
-  <name>Task 1: Evolve CrawlService with scope filtering, depth tracking, progress, and llms-full.txt hybrid ingestion</name>
+  <name>Task 1: IngestionService incremental ingestion with hash-based change detection</name>
+  <files>
+    src/main/java/dev/alexandria/ingestion/IngestionService.java
+    src/test/java/dev/alexandria/ingestion/IngestionServiceTest.java
+  </files>
+  <action>
+    **Add incremental ingestion method** to IngestionService. This task MUST be executed before Task 2, because Task 2 (CrawlService) calls `ingestionService.ingestPageIncremental()` defined here.
+
+    Add constructor dependencies:
+    - `IngestionStateRepository ingestionStateRepository`
+    - `EmbeddingStore<TextSegment> embeddingStore` (already available for chunk deletion -- currently only used transitively via storeChunks; need direct reference for removeAll)
+
+    Wait -- IngestionService already has `embeddingStore` field. Good. Add `ingestionStateRepository`.
+
+    **New method**: `public IngestResult ingestPageIncremental(UUID sourceId, String url, String markdown)`
+
+    **IngestResult record** (nested or in `ingestion/` package):
+    ```java
+    public record IngestResult(int chunksStored, boolean skipped, boolean changed) {}
+    ```
+    - `skipped = true` means content hash unchanged, no processing done
+    - `changed = true` means new or changed content, re-chunked and re-embedded
+
+    **Implementation flow** (per research pattern):
+    1. Normalize URL via `UrlNormalizer.normalize(url)`
+    2. Compute hash: `String newHash = ContentHasher.sha256(markdown)`
+    3. Look up existing state: `ingestionStateRepository.findBySourceIdAndPageUrl(sourceId, normalizedUrl)`
+    4. **If existing hash matches**: return `IngestResult(0, true, false)` -- skip entirely
+    5. **If hash differs or no record**:
+       a. Delete old chunks: `embeddingStore.removeAll(metadataKey("source_url").isEqualTo(normalizedUrl))` (using `import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey`)
+       b. Chunk and embed: call existing `ingestPage(markdown, normalizedUrl, Instant.now().toString())` which returns chunk count
+       c. Update or create IngestionState:
+          - If existing: `existing.setContentHash(newHash); existing.setLastIngestedAt(Instant.now()); ingestionStateRepository.save(existing)`
+          - If new: `ingestionStateRepository.save(new IngestionState(sourceId, normalizedUrl, newHash))`
+       d. Return `IngestResult(chunkCount, false, true)`
+
+    **Keep existing methods** (`ingest(List<CrawlResult>)` and `ingestPage(...)`) unchanged for backward compatibility. The new `ingestPageIncremental` is used by the evolved CrawlService (Task 2).
+
+    **Updated IngestionServiceTest**:
+    - Update existing tests for new constructor (mock ingestionStateRepository)
+    - `ingestPageIncrementalSkipsUnchangedContent` -- same hash returns skipped=true, no embedding/store calls
+    - `ingestPageIncrementalReprocessesChangedContent` -- different hash: deletes old chunks, re-chunks, re-embeds, updates state
+    - `ingestPageIncrementalCreatesNewStateForNewPage` -- no existing state: creates new IngestionState
+    - `ingestPageIncrementalDeletesOldChunksBeforeReingesting` -- verify removeAll called before addAll (ordering matters)
+    - Keep all existing test behaviors
+  </action>
+  <verify>
+    `./quality.sh test` passes. All IngestionService tests pass including new incremental tests. Run `./gradlew test --tests "dev.alexandria.ingestion.IngestionServiceTest"`.
+  </verify>
+  <done>IngestionService.ingestPageIncremental performs hash-based change detection: skips unchanged pages, deletes old chunks and re-ingests changed pages, and persists content hash state for future comparisons.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Evolve CrawlService with scope filtering, depth tracking, progress, and llms-full.txt hybrid ingestion</name>
   <files>
     src/main/java/dev/alexandria/crawl/CrawlService.java
     src/test/java/dev/alexandria/crawl/CrawlServiceTest.java
   </files>
   <action>
-    **Evolve CrawlService** to accept CrawlScope and sourceId, applying scope filtering and depth tracking during BFS crawl, with progress reporting and llms-full.txt hybrid support.
+    **Evolve CrawlService** to accept CrawlScope and sourceId, applying scope filtering and depth tracking during BFS crawl, with progress reporting and llms-full.txt hybrid support. This task depends on Task 1 which defines `ingestionService.ingestPageIncremental()`.
 
     **New method signature** (replace or overload existing `crawlSite`):
     ```java
@@ -104,7 +157,7 @@ Output: Updated CrawlService with full scope/incremental/progress support. Updat
 
     **Add new constructor dependencies**:
     - `CrawlProgressTracker progressTracker` (from Plan 03)
-    - `IngestionService ingestionService` (for incremental ingestion during crawl -- see Task 2)
+    - `IngestionService ingestionService` (for incremental ingestion during crawl -- API defined in Task 1)
     - `IngestionStateRepository ingestionStateRepository` (for change detection and orphan cleanup)
     - `EmbeddingStore<TextSegment> embeddingStore` (for per-page chunk deletion)
 
@@ -153,59 +206,6 @@ Output: Updated CrawlService with full scope/incremental/progress support. Updat
     `./quality.sh test` passes. All CrawlService tests pass including new scope/depth/progress tests. Run `./gradlew test --tests "dev.alexandria.crawl.CrawlServiceTest"`.
   </verify>
   <done>CrawlService applies scope filtering (block > allow priority), respects max depth, tracks progress via CrawlProgressTracker, handles llms-full.txt hybrid ingestion, and cleans up deleted pages post-crawl.</done>
-</task>
-
-<task type="auto">
-  <name>Task 2: IngestionService incremental ingestion with hash-based change detection</name>
-  <files>
-    src/main/java/dev/alexandria/ingestion/IngestionService.java
-    src/test/java/dev/alexandria/ingestion/IngestionServiceTest.java
-  </files>
-  <action>
-    **Add incremental ingestion method** to IngestionService:
-
-    Add constructor dependencies:
-    - `IngestionStateRepository ingestionStateRepository`
-    - `EmbeddingStore<TextSegment> embeddingStore` (already available for chunk deletion -- currently only used transitively via storeChunks; need direct reference for removeAll)
-
-    Wait -- IngestionService already has `embeddingStore` field. Good. Add `ingestionStateRepository`.
-
-    **New method**: `public IngestResult ingestPageIncremental(UUID sourceId, String url, String markdown)`
-
-    **IngestResult record** (nested or in `ingestion/` package):
-    ```java
-    public record IngestResult(int chunksStored, boolean skipped, boolean changed) {}
-    ```
-    - `skipped = true` means content hash unchanged, no processing done
-    - `changed = true` means new or changed content, re-chunked and re-embedded
-
-    **Implementation flow** (per research pattern):
-    1. Normalize URL via `UrlNormalizer.normalize(url)`
-    2. Compute hash: `String newHash = ContentHasher.sha256(markdown)`
-    3. Look up existing state: `ingestionStateRepository.findBySourceIdAndPageUrl(sourceId, normalizedUrl)`
-    4. **If existing hash matches**: return `IngestResult(0, true, false)` -- skip entirely
-    5. **If hash differs or no record**:
-       a. Delete old chunks: `embeddingStore.removeAll(metadataKey("source_url").isEqualTo(normalizedUrl))` (using `import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey`)
-       b. Chunk and embed: call existing `ingestPage(markdown, normalizedUrl, Instant.now().toString())` which returns chunk count
-       c. Update or create IngestionState:
-          - If existing: `existing.setContentHash(newHash); existing.setLastIngestedAt(Instant.now()); ingestionStateRepository.save(existing)`
-          - If new: `ingestionStateRepository.save(new IngestionState(sourceId, normalizedUrl, newHash))`
-       d. Return `IngestResult(chunkCount, false, true)`
-
-    **Keep existing methods** (`ingest(List<CrawlResult>)` and `ingestPage(...)`) unchanged for backward compatibility. The new `ingestPageIncremental` is used by the evolved CrawlService.
-
-    **Updated IngestionServiceTest**:
-    - Update existing tests for new constructor (mock ingestionStateRepository)
-    - `ingestPageIncrementalSkipsUnchangedContent` -- same hash returns skipped=true, no embedding/store calls
-    - `ingestPageIncrementalReprocessesChangedContent` -- different hash: deletes old chunks, re-chunks, re-embeds, updates state
-    - `ingestPageIncrementalCreatesNewStateForNewPage` -- no existing state: creates new IngestionState
-    - `ingestPageIncrementalDeletesOldChunksBeforeReingesting` -- verify removeAll called before addAll (ordering matters)
-    - Keep all existing test behaviors
-  </action>
-  <verify>
-    `./quality.sh test` passes. All IngestionService tests pass including new incremental tests. Run `./gradlew test --tests "dev.alexandria.ingestion.IngestionServiceTest"`.
-  </verify>
-  <done>IngestionService.ingestPageIncremental performs hash-based change detection: skips unchanged pages, deletes old chunks and re-ingests changed pages, and persists content hash state for future comparisons.</done>
 </task>
 
 </tasks>

--- a/.planning/phases/07-crawl-operations/07-04-SUMMARY.md
+++ b/.planning/phases/07-crawl-operations/07-04-SUMMARY.md
@@ -1,0 +1,125 @@
+---
+phase: 07-crawl-operations
+plan: 04
+subsystem: crawl, ingestion
+tags: [crawl-orchestration, scope-filtering, incremental-ingestion, content-hash, progress-tracking, llms-txt]
+
+# Dependency graph
+requires:
+  - phase: 07-01
+    provides: UrlScopeFilter for scope pattern matching, ContentHasher for SHA-256 hashing
+  - phase: 07-02
+    provides: PageDiscoveryService with llms.txt/llms-full.txt discovery and LlmsTxtParser
+  - phase: 07-03
+    provides: CrawlProgressTracker, CrawlProgress, CrawlScope, IngestionState, IngestionStateRepository
+provides:
+  - CrawlService with full scope-filtered, depth-tracked, incremental crawling
+  - IngestionService with deleteChunksForUrl and clearIngestionState
+  - Hash-based change detection avoiding re-ingestion of unchanged pages
+  - Deleted page cleanup removing orphaned chunks post-crawl
+  - llms-full.txt hybrid ingestion (direct ingest + gap filling)
+affects: [07-05-mcp-tools, future-recrawl]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [incremental-ingestion, hash-change-detection, depth-tracked-bfs, scope-filtered-crawl]
+
+key-files:
+  created: []
+  modified:
+    - src/main/java/dev/alexandria/crawl/CrawlService.java
+    - src/main/java/dev/alexandria/ingestion/IngestionService.java
+    - src/test/java/dev/alexandria/crawl/CrawlServiceTest.java
+    - src/test/java/dev/alexandria/ingestion/IngestionServiceTest.java
+    - src/integrationTest/java/dev/alexandria/ingestion/IngestionServiceIT.java
+
+key-decisions:
+  - "Incremental ingestion logic in CrawlService (not IngestionService) to avoid ArchUnit package cycle"
+  - "Removed ingest(List<CrawlResult>) from IngestionService to break ingestion->crawl dependency"
+  - "Added deleteChunksForUrl() to IngestionService as URL-scoped chunk deletion API"
+  - "CrawlService uses LinkedHashMap<URL, depth> for BFS with depth tracking"
+  - "llms-full.txt covered URLs tracked in HashSet and skipped during crawl loop"
+
+patterns-established:
+  - "Unidirectional dependency: crawl -> ingestion (never reverse)"
+  - "Incremental ingestion: hash check -> delete old -> re-ingest -> update state"
+  - "Post-crawl cleanup: compare ingestion state against crawled URLs set"
+
+requirements-completed: [CRWL-03, CRWL-06, CRWL-11]
+
+# Metrics
+duration: 10min
+completed: 2026-02-20
+---
+
+# Phase 7 Plan 4: Crawl Orchestration Summary
+
+**Scope-filtered BFS crawl with depth tracking, hash-based incremental ingestion, llms-full.txt hybrid ingest, progress reporting, and deleted page cleanup**
+
+## Performance
+
+- **Duration:** 10 min
+- **Started:** 2026-02-20T09:51:54Z
+- **Completed:** 2026-02-20T10:02:41Z
+- **Tasks:** 2
+- **Files modified:** 5
+
+## Accomplishments
+- CrawlService evolved from simple BFS to full scope-aware orchestrator with depth tracking, incremental ingestion, progress reporting, and llms-full.txt hybrid support
+- Hash-based change detection skips unchanged pages entirely, deletes old chunks and re-ingests changed pages
+- Post-crawl cleanup detects and removes orphaned pages (chunks + ingestion state)
+- ArchUnit package cycle resolved by moving incremental logic to CrawlService
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: IngestionService incremental ingestion** - `a5011f5` (feat)
+2. **Task 2: CrawlService scope/depth/progress/llms-full.txt** - `6150bee` (feat)
+
+## Files Created/Modified
+- `src/main/java/dev/alexandria/crawl/CrawlService.java` - Evolved with scope filtering, depth tracking, incremental ingestion, progress, llms-full.txt hybrid, deleted page cleanup
+- `src/main/java/dev/alexandria/ingestion/IngestionService.java` - Added deleteChunksForUrl, clearIngestionState; removed ingest(List<CrawlResult>) and crawl package imports
+- `src/test/java/dev/alexandria/crawl/CrawlServiceTest.java` - 17 tests covering existing + scope + depth + progress + llms-full.txt + cleanup + incremental
+- `src/test/java/dev/alexandria/ingestion/IngestionServiceTest.java` - 7 tests for ingestPage, deleteChunksForUrl, clearIngestionState
+- `src/integrationTest/java/dev/alexandria/ingestion/IngestionServiceIT.java` - Updated to use ingestPage instead of removed ingest(List<CrawlResult>)
+
+## Decisions Made
+- **Incremental ingestion in CrawlService**: Moved hash comparison and state management from IngestionService to CrawlService to avoid ArchUnit no_package_cycles violation (crawl<->ingestion bidirectional dependency)
+- **Removed ingest(List<CrawlResult>)**: This method created ingestion->crawl dependency via CrawlResult import; replaced with per-page ingestPage calls
+- **deleteChunksForUrl API**: Added to IngestionService as clean abstraction for URL-scoped chunk deletion, used by CrawlService for both incremental re-ingestion and orphaned page cleanup
+- **LinkedHashMap for depth-tracked BFS**: Maps URL to discovery depth, replaces LinkedHashSet; enables maxDepth enforcement without separate data structure
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] ArchUnit package cycle between crawl and ingestion packages**
+- **Found during:** Task 2 (CrawlService evolution)
+- **Issue:** CrawlService imported IngestionService/IngestionState/IngestionStateRepository (crawl->ingestion) while IngestionService imported CrawlResult/ContentHasher/UrlNormalizer (ingestion->crawl), creating a bidirectional dependency cycle detected by ArchUnit no_package_cycles rule
+- **Fix:** Moved incremental ingestion logic (hash check, state management) from IngestionService into CrawlService. Removed ingest(List<CrawlResult>) to eliminate CrawlResult import. Added deleteChunksForUrl() to IngestionService as abstraction for embedding store deletion. Updated integration test to use ingestPage() directly.
+- **Files modified:** IngestionService.java, CrawlService.java, IngestionServiceTest.java, CrawlServiceTest.java, IngestionServiceIT.java
+- **Verification:** All 199 tests pass including ArchUnit no_package_cycles
+- **Committed in:** 6150bee (Task 2 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking)
+**Impact on plan:** Architectural change was necessary to maintain ArchUnit package cycle enforcement. No scope creep -- same functionality, different code location.
+
+## Issues Encountered
+None beyond the ArchUnit deviation described above.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- CrawlService ready for MCP tool integration (Plan 05)
+- crawlSite(UUID, String, CrawlScope) is the new primary API for source-aware crawling
+- clearIngestionState(UUID) available for full recrawl reset
+- All Plan 01-04 utilities integrated into working crawl orchestrator
+
+---
+*Phase: 07-crawl-operations*
+*Completed: 2026-02-20*

--- a/.planning/phases/07-crawl-operations/07-05-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-05-PLAN.md
@@ -1,0 +1,240 @@
+---
+phase: 07-crawl-operations
+plan: 05
+type: execute
+wave: 4
+depends_on:
+  - "07-04"
+files_modified:
+  - src/main/java/dev/alexandria/mcp/McpToolService.java
+  - src/test/java/dev/alexandria/mcp/McpToolServiceTest.java
+autonomous: true
+requirements:
+  - CRWL-03
+  - CRWL-07
+  - CRWL-09
+  - CRWL-10
+
+must_haves:
+  truths:
+    - "add_source MCP tool accepts scope parameters and triggers crawl orchestration"
+    - "crawl_status MCP tool returns real-time progress for active crawls and summary for completed crawls"
+    - "recrawl_source MCP tool triggers incremental recrawl with optional scope override and full flag"
+    - "No automatic/scheduled recrawls -- only manual recrawl_source (CRWL-07 satisfied as deferred)"
+  artifacts:
+    - path: "src/main/java/dev/alexandria/mcp/McpToolService.java"
+      provides: "Real MCP tool implementations replacing stubs"
+      contains: "crawlService.crawlSite"
+    - path: "src/test/java/dev/alexandria/mcp/McpToolServiceTest.java"
+      provides: "Updated unit tests for all 6 MCP tools"
+      min_lines: 100
+  key_links:
+    - from: "src/main/java/dev/alexandria/mcp/McpToolService.java"
+      to: "src/main/java/dev/alexandria/crawl/CrawlService.java"
+      via: "addSource and recrawlSource invoke CrawlService.crawlSite"
+      pattern: "crawlService\\.crawlSite"
+    - from: "src/main/java/dev/alexandria/mcp/McpToolService.java"
+      to: "src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java"
+      via: "crawlStatus reads from progress tracker"
+      pattern: "progressTracker\\.getProgress"
+    - from: "src/main/java/dev/alexandria/mcp/McpToolService.java"
+      to: "src/main/java/dev/alexandria/source/Source.java"
+      via: "addSource creates Source with scope config, recrawl reads scope from Source"
+      pattern: "source\\.toCrawlScope"
+---
+
+<objective>
+Replace the stub MCP tool implementations in McpToolService with real orchestration: add_source triggers crawl with scope parameters, crawl_status returns real-time progress, recrawl_source triggers incremental recrawl.
+
+Purpose: This is the user-facing layer that connects MCP tools to the crawl orchestration built in Plans 01-04. After this plan, users can add sources with scope control, monitor crawl progress, and trigger recrawls -- all through Claude Code MCP tools.
+Output: Fully functional add_source, crawl_status, and recrawl_source MCP tools.
+</objective>
+
+<execution_context>
+@./.claude/get-shit-done/workflows/execute-plan.md
+@./.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/07-crawl-operations/07-RESEARCH.md
+@.planning/phases/07-crawl-operations/07-04-SUMMARY.md
+@src/main/java/dev/alexandria/mcp/McpToolService.java
+@src/main/java/dev/alexandria/crawl/CrawlService.java
+@src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java
+@src/main/java/dev/alexandria/crawl/CrawlScope.java
+@src/main/java/dev/alexandria/source/Source.java
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Replace MCP tool stubs with real crawl orchestration</name>
+  <files>
+    src/main/java/dev/alexandria/mcp/McpToolService.java
+  </files>
+  <action>
+    **Add new constructor dependencies** to McpToolService:
+    - `CrawlService crawlService`
+    - `CrawlProgressTracker progressTracker`
+    - `IngestionService ingestionService` (if needed for chunk count updates)
+
+    **Replace addSource** tool:
+    - Add optional scope parameters to `@ToolParam`:
+      ```java
+      @Tool(name = "add_source",
+            description = "Add a documentation source URL for crawling and indexing. "
+                        + "Optionally specify scope controls: allow/block URL patterns (glob), max depth, max pages.")
+      public String addSource(
+          @ToolParam(description = "URL of the documentation site to index") String url,
+          @ToolParam(description = "Human-readable name for this source") String name,
+          @ToolParam(description = "Comma-separated glob patterns for allowed URL paths (e.g., '/docs/**,/api/**'). Empty = allow all.", required = false) String allowPatterns,
+          @ToolParam(description = "Comma-separated glob patterns for blocked URL paths (e.g., '/archive/**,/old/**'). Empty = block none.", required = false) String blockPatterns,
+          @ToolParam(description = "Maximum crawl depth from root URL. Null = unlimited.", required = false) Integer maxDepth,
+          @ToolParam(description = "Maximum number of pages to crawl (default: 500).", required = false) Integer maxPages,
+          @ToolParam(description = "Manual llms.txt URL if auto-detection fails.", required = false) String llmsTxtUrl)
+      ```
+    - Create Source with scope fields populated:
+      ```java
+      Source source = new Source(url, name);
+      source.setAllowPatterns(allowPatterns);
+      source.setBlockPatterns(blockPatterns);
+      source.setMaxDepth(maxDepth);
+      source.setMaxPages(maxPages != null ? maxPages : 500);
+      source.setLlmsTxtUrl(llmsTxtUrl);
+      source.setStatus(SourceStatus.CRAWLING);
+      sourceRepository.save(source);
+      ```
+    - Trigger async crawl (use virtual threads -- `Thread.startVirtualThread(() -> ...)` or `CompletableFuture.runAsync()`):
+      ```java
+      UUID sourceId = source.getId();
+      CrawlScope scope = source.toCrawlScope();
+      Thread.startVirtualThread(() -> {
+          try {
+              List<CrawlResult> results = crawlService.crawlSite(sourceId, url, scope);
+              source.setStatus(SourceStatus.INDEXED);
+              source.setLastCrawledAt(Instant.now());
+              source.setChunkCount(/* count from results */);
+              sourceRepository.save(source);
+          } catch (Exception e) {
+              source.setStatus(SourceStatus.ERROR);
+              sourceRepository.save(source);
+          }
+      });
+      ```
+    - Return immediately with source ID and status message: `"Source '%s' created (ID: %s). Crawl started. Check progress with crawl_status.".formatted(name, source.getId())`
+
+    **Replace crawlStatus** tool:
+    - Check CrawlProgressTracker first (for active crawls):
+      ```java
+      Optional<CrawlProgress> progress = progressTracker.getProgress(uuid);
+      if (progress.isPresent()) {
+          CrawlProgress p = progress.get();
+          // Format real-time progress
+          return formatActiveProgress(source, p);
+      }
+      ```
+    - If no active crawl, show summary from Source entity (for completed/idle sources):
+      ```java
+      return formatCompletedSummary(source);
+      ```
+    - `formatActiveProgress`: structured text with source name, URL, status, pages crawled/total, skipped, errors (with URLs), filtered (with URLs), elapsed time. Follow format from 07-RESEARCH.md discretion recommendation.
+    - `formatCompletedSummary`: source name, URL, status, last crawl time, chunk count.
+    - Include filtered URLs in active progress output (per user decision: "URLs filtered by scope are logged, available in crawl_status output")
+
+    **Replace recrawlSource** tool:
+    - Add scope override and full flag parameters:
+      ```java
+      @Tool(name = "recrawl_source",
+            description = "Trigger a recrawl of an existing documentation source. "
+                        + "Incremental by default (only re-processes changed pages). Use full=true to force complete re-processing.")
+      public String recrawlSource(
+          @ToolParam(description = "UUID of the source to re-crawl") String sourceId,
+          @ToolParam(description = "Force full recrawl (re-process all pages, not just changed ones)", required = false) Boolean full,
+          @ToolParam(description = "Override allow patterns for this crawl run (comma-separated globs)", required = false) String allowPatterns,
+          @ToolParam(description = "Override block patterns for this crawl run (comma-separated globs)", required = false) String blockPatterns,
+          @ToolParam(description = "Override max depth for this crawl run", required = false) Integer maxDepth,
+          @ToolParam(description = "Override max pages for this crawl run", required = false) Integer maxPages)
+      ```
+    - Look up source, validate it exists and is not currently CRAWLING
+    - Build CrawlScope: use override params if provided, else fall back to source's stored scope config (per user decision: "overrides don't persist, they're one-time for that crawl run")
+    - If `full == true`: clear all IngestionState records for this source (`ingestionStateRepository.deleteAllBySourceId(sourceId)`) so every page is re-processed
+    - Update source status to UPDATING
+    - Trigger async crawl via virtual thread (same pattern as addSource)
+    - Return: `"Recrawl started for '%s' (%s mode). Check progress with crawl_status.".formatted(source.getName(), full ? "full" : "incremental")`
+
+    **Important**: Scope overrides on recrawl do NOT persist to the Source entity. They are used only for constructing the CrawlScope for this crawl run. The Source entity's scope fields remain unchanged.
+
+    **Update Javadoc** on McpToolService class to reflect the tools are now fully functional (remove "stub" references).
+  </action>
+  <verify>
+    `./quality.sh test` passes. All McpToolService tests pass including new ones. Verify async crawl does not block the MCP response.
+  </verify>
+  <done>add_source creates source with scope config and triggers async crawl. crawl_status returns real-time progress during crawl and summary after. recrawl_source triggers incremental or full recrawl with optional scope overrides.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update McpToolService unit tests for real implementations</name>
+  <files>
+    src/test/java/dev/alexandria/mcp/McpToolServiceTest.java
+  </files>
+  <action>
+    **Update existing tests** for new constructor signature (mock new dependencies: CrawlService, CrawlProgressTracker).
+
+    **Update addSource tests**:
+    - `addSourceCreatesSourceWithScopeAndTriggersCrawl` -- verify Source saved with scope fields, verify crawl triggered asynchronously
+    - `addSourceWithNullScopeUsesDefaults` -- verify defaults (empty patterns, null maxDepth, 500 maxPages)
+    - `addSourceReturnsImmediatelyWithId` -- verify response includes source ID and "Crawl started" message
+    - Keep existing `addSourceWithEmptyUrlReturnsError` test
+
+    **Update crawlStatus tests**:
+    - `crawlStatusShowsActiveProgress` -- mock progressTracker returning CrawlProgress with CRAWLING status, verify output includes pages crawled/total/errors
+    - `crawlStatusShowsCompletedSummary` -- mock progressTracker returning empty (no active crawl), verify output shows source entity summary
+    - `crawlStatusShowsFilteredUrls` -- mock progress with filtered URLs, verify they appear in output
+    - Keep existing `crawlStatusWithInvalidIdReturnsError` and `crawlStatusWithMissingSourceReturnsError` tests
+
+    **Update recrawlSource tests**:
+    - `recrawlSourceTriggersIncrementalByDefault` -- verify crawlService.crawlSite called, IngestionState NOT cleared
+    - `recrawlSourceWithFullFlagClearsStateFirst` -- verify ingestionStateRepository.deleteAllBySourceId called when full=true
+    - `recrawlSourceWithScopeOverridesUsesOverrides` -- verify CrawlScope built from override params, not source entity fields
+    - `recrawlSourceRejectsActivelyRunningCrawl` -- source with CRAWLING status returns error message
+    - Keep existing `recrawlSourceWithInvalidIdReturnsError` and `recrawlSourceWithMissingSourceReturnsError` tests
+
+    **Testing async behavior**:
+    - For async crawl tests, verify the crawlService is invoked but don't wait for completion. Use `verify(crawlService, timeout(1000)).crawlSite(...)` or simply verify that the method returns immediately with the expected message without blocking.
+    - Alternatively, extract the async dispatch into a package-private method that tests can intercept, or use `@VisibleForTesting` to make the crawl runnable testable.
+
+    **Follow existing test patterns**: Use `@ExtendWith(MockitoExtension.class)` with `@Mock` and `@InjectMocks`. Follow BDDMockito `given/willReturn` style per Phase 5 patterns.
+  </action>
+  <verify>
+    `./quality.sh test` passes. All McpToolService tests pass. Run `./gradlew test --tests "dev.alexandria.mcp.McpToolServiceTest"`. All ~25+ tests green.
+  </verify>
+  <done>All 6 MCP tool methods have comprehensive unit tests. add_source, crawl_status, and recrawl_source tests verify real orchestration behavior. No regressions in existing search_docs and list_sources tests.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `./quality.sh test` passes with all tests green
+- add_source creates source with scope config and returns immediately
+- crawl_status shows real-time progress for active crawls, summary for completed
+- recrawl_source supports full and incremental modes with scope overrides
+- No automatic scheduling -- only manual recrawl_source (CRWL-07 satisfied)
+- Filtered URLs appear in crawl_status output (per user decision)
+- Scope overrides on recrawl are one-time, not persisted to Source
+</verification>
+
+<success_criteria>
+- All MCP tool tests verify real behavior (not stub responses)
+- add_source with scope params verified in tests
+- crawl_status active/completed/filtered outputs verified
+- recrawl_source incremental/full/override modes verified
+- Async crawl does not block MCP response
+- No regressions in existing ~130+ tests
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/07-crawl-operations/07-05-SUMMARY.md`
+</output>

--- a/.planning/phases/07-crawl-operations/07-05-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-05-PLAN.md
@@ -114,16 +114,22 @@ Output: Fully functional add_source, crawl_status, and recrawl_source MCP tools.
       Thread.startVirtualThread(() -> {
           try {
               List<CrawlResult> results = crawlService.crawlSite(sourceId, url, scope);
-              source.setStatus(SourceStatus.INDEXED);
-              source.setLastCrawledAt(Instant.now());
-              source.setChunkCount(/* count from results */);
-              sourceRepository.save(source);
+              // IMPORTANT: Re-fetch the source entity inside the virtual thread to avoid
+              // JPA session boundary errors. The outer `source` reference is detached
+              // from the JPA session once the original request thread completes.
+              Source freshSource = sourceRepository.findById(sourceId).orElseThrow();
+              freshSource.setStatus(SourceStatus.INDEXED);
+              freshSource.setLastCrawledAt(Instant.now());
+              freshSource.setChunkCount(/* count from results */);
+              sourceRepository.save(freshSource);
           } catch (Exception e) {
-              source.setStatus(SourceStatus.ERROR);
-              sourceRepository.save(source);
+              Source freshSource = sourceRepository.findById(sourceId).orElseThrow();
+              freshSource.setStatus(SourceStatus.ERROR);
+              sourceRepository.save(freshSource);
           }
       });
       ```
+      **JPA session boundary rule**: Never use a JPA entity reference captured from the outer scope inside a virtual thread. Always re-fetch by ID within the new thread. This applies to both the addSource and recrawlSource async blocks.
     - Return immediately with source ID and status message: `"Source '%s' created (ID: %s). Crawl started. Check progress with crawl_status.".formatted(name, source.getId())`
 
     **Replace crawlStatus** tool:

--- a/.planning/phases/07-crawl-operations/07-05-PLAN.md
+++ b/.planning/phases/07-crawl-operations/07-05-PLAN.md
@@ -79,7 +79,7 @@ Output: Fully functional add_source, crawl_status, and recrawl_source MCP tools.
     **Add new constructor dependencies** to McpToolService:
     - `CrawlService crawlService`
     - `CrawlProgressTracker progressTracker`
-    - `IngestionService ingestionService` (if needed for chunk count updates)
+    - `IngestionService ingestionService` (required: clears ingestion state on full recrawl via `ingestionService.clearIngestionState(sourceId)`, and may be used for chunk count updates)
 
     **Replace addSource** tool:
     - Add optional scope parameters to `@ToolParam`:
@@ -166,7 +166,7 @@ Output: Fully functional add_source, crawl_status, and recrawl_source MCP tools.
       ```
     - Look up source, validate it exists and is not currently CRAWLING
     - Build CrawlScope: use override params if provided, else fall back to source's stored scope config (per user decision: "overrides don't persist, they're one-time for that crawl run")
-    - If `full == true`: clear all IngestionState records for this source (`ingestionStateRepository.deleteAllBySourceId(sourceId)`) so every page is re-processed
+    - If `full == true`: clear all IngestionState records for this source via `ingestionService.clearIngestionState(sourceId)` (defined in Plan 04, Task 1 -- keeps repository boundary inside the ingestion service layer, no IngestionStateRepository injection into McpToolService)
     - Update source status to UPDATING
     - Trigger async crawl via virtual thread (same pattern as addSource)
     - Return: `"Recrawl started for '%s' (%s mode). Check progress with crawl_status.".formatted(source.getName(), full ? "full" : "incremental")`
@@ -187,7 +187,7 @@ Output: Fully functional add_source, crawl_status, and recrawl_source MCP tools.
     src/test/java/dev/alexandria/mcp/McpToolServiceTest.java
   </files>
   <action>
-    **Update existing tests** for new constructor signature (mock new dependencies: CrawlService, CrawlProgressTracker).
+    **Update existing tests** for new constructor signature (mock new dependencies: `CrawlService crawlService`, `CrawlProgressTracker progressTracker`, `IngestionService ingestionService`). Do NOT add `@Mock IngestionStateRepository` -- McpToolService only depends on IngestionService, not the repository directly.
 
     **Update addSource tests**:
     - `addSourceCreatesSourceWithScopeAndTriggersCrawl` -- verify Source saved with scope fields, verify crawl triggered asynchronously
@@ -203,7 +203,7 @@ Output: Fully functional add_source, crawl_status, and recrawl_source MCP tools.
 
     **Update recrawlSource tests**:
     - `recrawlSourceTriggersIncrementalByDefault` -- verify crawlService.crawlSite called, IngestionState NOT cleared
-    - `recrawlSourceWithFullFlagClearsStateFirst` -- verify ingestionStateRepository.deleteAllBySourceId called when full=true
+    - `recrawlSourceWithFullFlagClearsStateFirst` -- verify `ingestionService.clearIngestionState(sourceId)` called when full=true (NOT ingestionStateRepository directly)
     - `recrawlSourceWithScopeOverridesUsesOverrides` -- verify CrawlScope built from override params, not source entity fields
     - `recrawlSourceRejectsActivelyRunningCrawl` -- source with CRAWLING status returns error message
     - Keep existing `recrawlSourceWithInvalidIdReturnsError` and `recrawlSourceWithMissingSourceReturnsError` tests

--- a/.planning/phases/07-crawl-operations/07-05-SUMMARY.md
+++ b/.planning/phases/07-crawl-operations/07-05-SUMMARY.md
@@ -1,0 +1,121 @@
+---
+phase: 07-crawl-operations
+plan: 05
+subsystem: mcp
+tags: [mcp, crawl, virtual-threads, async, scope-filtering]
+
+requires:
+  - phase: 07-04
+    provides: "CrawlService orchestration with incremental ingestion, CrawlProgressTracker, CrawlScope.fromSource()"
+  - phase: 05-mcp-server
+    provides: "McpToolService with stub tool implementations, TokenBudgetTruncator"
+provides:
+  - "Fully functional add_source MCP tool with scope parameters and async crawl dispatch"
+  - "Real-time crawl_status MCP tool showing active progress and completed summaries"
+  - "recrawl_source MCP tool with incremental/full modes and one-time scope overrides"
+affects: [08-polish-hardening]
+
+tech-stack:
+  added: []
+  patterns: [virtual-thread-dispatch, spy-based-async-testing, scope-override-without-persist]
+
+key-files:
+  created: []
+  modified:
+    - src/main/java/dev/alexandria/mcp/McpToolService.java
+    - src/test/java/dev/alexandria/mcp/McpToolServiceTest.java
+
+key-decisions:
+  - "dispatchCrawl extracted as package-private method for testability -- spy pattern suppresses virtual thread in unit tests"
+  - "Scope overrides on recrawl are one-time: CrawlScope built from overrides, Source entity unchanged"
+  - "results.size() used for chunkCount on Source after crawl (page count proxy; actual chunk counts tracked internally by CrawlService)"
+
+patterns-established:
+  - "suppressAsyncDispatch() test helper: spy on service, doNothing on dispatchCrawl to avoid virtual thread races in unit tests"
+  - "Reject recrawl when source status is CRAWLING or UPDATING (active crawl guard)"
+
+requirements-completed: [CRWL-03, CRWL-07, CRWL-09, CRWL-10]
+
+duration: 6min
+completed: 2026-02-20
+---
+
+# Phase 7 Plan 5: MCP Tool Integration Summary
+
+**Fully functional MCP tools: add_source with scope-controlled async crawl, real-time crawl_status with filtered/error URL reporting, recrawl_source with incremental/full modes and one-time scope overrides**
+
+## Performance
+
+- **Duration:** 6 min
+- **Started:** 2026-02-20T10:05:42Z
+- **Completed:** 2026-02-20T10:11:47Z
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+- Replaced all 3 stub MCP tools (add_source, crawl_status, recrawl_source) with full orchestration implementations
+- add_source now accepts scope parameters (allow/block patterns, maxDepth, maxPages, llmsTxtUrl) and triggers async crawl via virtual threads
+- crawl_status shows real-time progress (pages crawled/total, skipped, errors with URLs, filtered URLs) for active crawls and summary for completed sources
+- recrawl_source supports incremental (default) and full modes with optional one-time scope overrides that don't persist to Source entity
+- 30 unit tests covering all 6 MCP tools (211 total tests pass, 0 regressions)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Replace MCP tool stubs with real crawl orchestration** - `6114d6e` (feat)
+2. **Task 2: Update McpToolService unit tests for real implementations** - `2975e9e` (test)
+
+## Files Created/Modified
+- `src/main/java/dev/alexandria/mcp/McpToolService.java` - Full MCP tool implementations with CrawlService/CrawlProgressTracker/IngestionService integration, async dispatch via virtual threads
+- `src/test/java/dev/alexandria/mcp/McpToolServiceTest.java` - 30 unit tests covering all tools: scope params, active/completed status, filtered URLs, full/incremental recrawl, error handling
+
+## Decisions Made
+- **dispatchCrawl as package-private method**: Extracted virtual thread dispatch for testability. Tests use Mockito spy with doNothing() to suppress async execution, avoiding race conditions.
+- **Scope overrides are one-time**: recrawlSource builds CrawlScope from override params without modifying Source entity fields. Per user decision from plan.
+- **results.size() for chunkCount**: Since CrawlService handles ingestion internally, the page count from results is used as a proxy for chunk count on Source entity. Actual chunk counts are tracked per-page inside CrawlService.
+- **Reject recrawl for CRAWLING and UPDATING statuses**: Both indicate an active crawl operation; allowing concurrent crawls would cause data races.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Added UPDATING status check to recrawl rejection**
+- **Found during:** Task 1
+- **Issue:** Plan only mentioned rejecting CRAWLING status, but UPDATING also indicates an active recrawl in progress
+- **Fix:** Added `source.getStatus() == SourceStatus.UPDATING` check alongside CRAWLING
+- **Files modified:** src/main/java/dev/alexandria/mcp/McpToolService.java
+- **Verification:** recrawlSourceRejectsUpdatingSource test passes
+- **Committed in:** 6114d6e (Task 1 commit)
+
+**2. [Rule 1 - Bug] Used CrawlScope.fromSource() instead of source.toCrawlScope()**
+- **Found during:** Task 1
+- **Issue:** Plan code snippets used `source.toCrawlScope()` which doesn't exist. Per 07-03/07-04 architectural decision, CrawlScope.fromSource(Source) is the correct factory to maintain unidirectional crawl->source dependency.
+- **Fix:** Used `CrawlScope.fromSource(source)` throughout
+- **Files modified:** src/main/java/dev/alexandria/mcp/McpToolService.java
+- **Verification:** ArchUnit architecture tests pass (no package cycles)
+- **Committed in:** 6114d6e (Task 1 commit)
+
+---
+
+**Total deviations:** 2 auto-fixed (2 bugs)
+**Impact on plan:** Both fixes were necessary for correctness and ArchUnit compliance. No scope creep.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Phase 7 (Crawl Operations) is fully complete: all 5 plans executed
+- All MCP tools are functional end-to-end: add_source -> crawl_status -> recrawl_source
+- Ready for Phase 8 (Polish & Hardening)
+
+## Self-Check: PASSED
+
+All files verified present, all commits verified in git log.
+
+---
+*Phase: 07-crawl-operations*
+*Completed: 2026-02-20*

--- a/.planning/phases/07-crawl-operations/07-CONTEXT.md
+++ b/.planning/phases/07-crawl-operations/07-CONTEXT.md
@@ -1,0 +1,70 @@
+# Phase 7: Crawl Operations - Context
+
+**Gathered:** 2026-02-20
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Users have full operational control over crawling -- scope limits, incremental updates, manual recrawls, progress monitoring, and llms.txt support. No automatic/scheduled recrawls in this phase. Scheduling is deferred.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Scope Controls
+- Glob patterns for allowlist/blocklist (e.g., `/docs/**`, `!/docs/archive/**`)
+- Scope defined at `add_source` time, overridable via `recrawl_source` params
+- Max depth unlimited by default (no default cap)
+- Max pages configurable per source
+- URLs filtered by scope are logged (not silently skipped) -- available in `crawl_status` output
+
+### Incremental Crawl Behavior
+- Content hash (SHA-256) per page determines change detection
+- Unchanged pages (same hash): skip entirely -- no re-chunking, no re-embedding
+- Changed pages (different hash): delete all old chunks for that page, re-chunk and re-embed from scratch (replace-all strategy)
+- Deleted pages: detected by comparing crawled URLs against indexed URLs post-crawl -- chunks for missing pages are deleted
+- No diff-based chunk comparison -- full replacement per page is simpler and reliable
+
+### Scheduling & Recrawl
+- **No automatic/scheduled recrawls** -- only manual recrawl via `recrawl_source` MCP tool
+- Recrawl is incremental by default, with a `full` flag to force complete re-processing
+- Recrawl can override scope params (patterns, max_depth, max_pages) for that run, defaults to original source config
+
+### llms.txt Support
+- Auto-detection: check `/llms.txt` and `/llms-full.txt` at domain root when adding a source
+- User can manually provide llms.txt URL if auto-detection fails
+- Discovery priority cascade: llms.txt > sitemap.xml > link crawl (each level supplements the previous)
+- llms-full.txt: hybrid ingestion -- use as primary content source (ingest directly), then crawl any pages from llms.txt/sitemap/links not covered by llms-full.txt
+- Handles incomplete llms-full.txt gracefully by filling gaps via crawling
+
+### Claude's Discretion
+- Progress reporting format and detail level in `crawl_status`
+- Hash storage mechanism (column on existing table vs separate tracking table)
+- Glob pattern matching library choice
+- llms.txt parsing implementation details
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- "J'ai deja vu des llms-full.txt qui n'etait pas complet" -- hybrid approach important to fill gaps
+- Scheduling explicitly deferred: user prefers manual control for now
+- Scope overrides on recrawl should not persist -- they're one-time for that crawl run
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- Automatic/scheduled recrawls (cron or interval-based) -- future phase or backlog
+- Scope persistence updates (ability to permanently change a source's scope config after initial add)
+
+</deferred>
+
+---
+
+*Phase: 07-crawl-operations*
+*Context gathered: 2026-02-20*

--- a/.planning/phases/07-crawl-operations/07-RESEARCH.md
+++ b/.planning/phases/07-crawl-operations/07-RESEARCH.md
@@ -1,0 +1,515 @@
+# Phase 7: Crawl Operations - Research
+
+**Researched:** 2026-02-20
+**Domain:** Crawl scope control, incremental crawling, progress tracking, llms.txt ingestion
+**Confidence:** HIGH
+
+## Summary
+
+Phase 7 adds operational control to the existing crawling infrastructure. The codebase already has the foundational pieces: `CrawlService` manages BFS crawl orchestration, `IngestionService` handles chunking and embedding, `IngestionState` tracks per-page content hashes in the database, and `McpToolService` has stub implementations for `add_source`, `crawl_status`, and `recrawl_source`. The work is primarily about connecting these pieces with scope filtering, incremental change detection, progress tracking, and llms.txt discovery.
+
+The key architectural insight is that Alexandria manages its own crawl loop (CrawlService does BFS page-by-page), calling Crawl4AI's REST API only for single-page rendering. This means max_depth, URL filtering, and scope controls are all implemented in Alexandria's Java code, not delegated to Crawl4AI. The incremental crawl system already has its database table (`ingestion_state`) and JPA entity (`IngestionState`) with `findBySourceIdAndPageUrl` -- the core infrastructure for SHA-256 change detection exists; it just needs to be wired into the crawl/ingestion flow.
+
+**Primary recommendation:** Evolve CrawlService to accept scope parameters (patterns, maxDepth, maxPages), add a CrawlProgressTracker for real-time status, wire IngestionState into the ingestion pipeline for change detection, and add an LlmsTxtParser as a third URL discovery strategy in PageDiscoveryService.
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+#### Scope Controls
+- Glob patterns for allowlist/blocklist (e.g., `/docs/**`, `!/docs/archive/**`)
+- Scope defined at `add_source` time, overridable via `recrawl_source` params
+- Max depth unlimited by default (no default cap)
+- Max pages configurable per source
+- URLs filtered by scope are logged (not silently skipped) -- available in `crawl_status` output
+
+#### Incremental Crawl Behavior
+- Content hash (SHA-256) per page determines change detection
+- Unchanged pages (same hash): skip entirely -- no re-chunking, no re-embedding
+- Changed pages (different hash): delete all old chunks for that page, re-chunk and re-embed from scratch (replace-all strategy)
+- Deleted pages: detected by comparing crawled URLs against indexed URLs post-crawl -- chunks for missing pages are deleted
+- No diff-based chunk comparison -- full replacement per page is simpler and reliable
+
+#### Scheduling & Recrawl
+- **No automatic/scheduled recrawls** -- only manual recrawl via `recrawl_source` MCP tool
+- Recrawl is incremental by default, with a `full` flag to force complete re-processing
+- Recrawl can override scope params (patterns, max_depth, max_pages) for that run, defaults to original source config
+
+#### llms.txt Support
+- Auto-detection: check `/llms.txt` and `/llms-full.txt` at domain root when adding a source
+- User can manually provide llms.txt URL if auto-detection fails
+- Discovery priority cascade: llms.txt > sitemap.xml > link crawl (each level supplements the previous)
+- llms-full.txt: hybrid ingestion -- use as primary content source (ingest directly), then crawl any pages from llms.txt/sitemap/links not covered by llms-full.txt
+- Handles incomplete llms-full.txt gracefully by filling gaps via crawling
+
+### Claude's Discretion
+- Progress reporting format and detail level in `crawl_status`
+- Hash storage mechanism (column on existing table vs separate tracking table)
+- Glob pattern matching library choice
+- llms.txt parsing implementation details
+
+### Deferred Ideas (OUT OF SCOPE)
+- Automatic/scheduled recrawls (cron or interval-based) -- future phase or backlog
+- Scope persistence updates (ability to permanently change a source's scope config after initial add)
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|-----------------|
+| CRWL-03 | User can control crawl scope (URL pattern allowlist/blocklist, max depth, max pages) | Glob pattern matching via `java.nio.file.PathMatcher` or Spring AntPathMatcher for URL path filtering; CrawlService already accepts maxPages; need to add depth tracking and pattern filtering |
+| CRWL-06 | System performs incremental/delta crawls -- only re-processes pages whose content hash (SHA-256) has changed | `IngestionState` entity and `ingestion_state` table already exist with SHA-256 hash storage; `IngestionStateRepository.findBySourceIdAndPageUrl()` already defined; needs wiring into ingestion flow |
+| CRWL-07 | User can schedule periodic recrawls (interval-based) | **DEFERRED per CONTEXT.md** -- only manual `recrawl_source` MCP tool in this phase |
+| CRWL-09 | User can check crawl progress (pages crawled, pages remaining, errors) via MCP tool `crawl_status` | McpToolService.crawlStatus() stub exists; needs real-time progress tracking via in-memory state or DB |
+| CRWL-10 | User can trigger a recrawl of an existing source via MCP tool `recrawl_source` | McpToolService.recrawlSource() stub exists; needs to invoke CrawlService with scope params and incremental logic |
+| CRWL-11 | System can ingest llms.txt and llms-full.txt files as documentation sources and use them for page discovery | New LlmsTxtParser needed; integrates into PageDiscoveryService as highest-priority discovery method |
+</phase_requirements>
+
+## Standard Stack
+
+### Core (already in project)
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| Java JDK | 21 | `java.security.MessageDigest` for SHA-256, `java.nio.file.PathMatcher` for glob matching | Zero-dependency -- JDK built-ins are sufficient for both hashing and glob matching |
+| Spring Boot | 3.5.7 | Web framework, DI, RestClient for HTTP | Already the project foundation |
+| LangChain4j | 1.11.0-beta19 | `EmbeddingStore.removeAll(Filter)` for chunk deletion by metadata | Already used; `removeAll(metadataKey("source_url").isEqualTo(...))` pattern proven in PreChunkedImporter |
+| Spring Data JPA | (managed) | Repository queries for IngestionState, Source, DocumentChunk | Already used throughout |
+
+### Supporting (no new dependencies needed)
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| `java.security.MessageDigest` | JDK 21 | SHA-256 content hashing | Hash page content for change detection |
+| `java.nio.file.FileSystems.getDefault().getPathMatcher()` | JDK 21 | Glob pattern matching on URL paths | Filter URLs against allowlist/blocklist patterns |
+| Spring `RestClient` | (managed) | HTTP GET for llms.txt/llms-full.txt fetching | Already configured via `RestClient.Builder` in SitemapParser |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| JDK `PathMatcher` for globs | hrakaroo/glob-library-java 0.9.0 | Faster (1.5x) but adds dependency for a non-critical path; URL filtering is not performance-sensitive |
+| JDK `PathMatcher` for globs | Spring `AntPathMatcher` | Already on classpath; uses Ant-style patterns (`**`) instead of glob syntax, but less standard for user-facing patterns |
+| JDK `MessageDigest` | Guava Hashing or Apache Commons DigestUtils | Convenience wrappers but add dependency for a 5-line utility method |
+
+**No new dependencies required.** All capabilities are provided by JDK 21 built-ins and libraries already in the project.
+
+## Architecture Patterns
+
+### Current Package Structure (relevant to Phase 7)
+```
+dev.alexandria/
+├── crawl/              # CrawlService, Crawl4AiClient, PageDiscoveryService, SitemapParser
+├── ingestion/          # IngestionService, IngestionState, IngestionStateRepository
+│   ├── chunking/       # MarkdownChunker, DocumentChunkData
+│   └── prechunked/     # PreChunkedImporter
+├── source/             # Source entity, SourceStatus enum, SourceRepository
+├── document/           # DocumentChunk entity, DocumentChunkRepository
+├── mcp/                # McpToolService (stubs for crawl_status, recrawl_source)
+└── config/             # EmbeddingConfig, GlobalExceptionHandler
+```
+
+### Pattern 1: Scope Configuration as Records
+**What:** Represent crawl scope as an immutable record that travels with crawl requests
+**When to use:** Passing scope from MCP tools through to CrawlService
+
+```java
+// New record in crawl/ package
+public record CrawlScope(
+    List<String> allowPatterns,   // e.g. ["/docs/**"]
+    List<String> blockPatterns,   // e.g. ["!/docs/archive/**"]
+    Integer maxDepth,             // null = unlimited
+    int maxPages                  // required, default from Source
+) {
+    public CrawlScope {
+        allowPatterns = allowPatterns == null ? List.of() : List.copyOf(allowPatterns);
+        blockPatterns = blockPatterns == null ? List.of() : List.copyOf(blockPatterns);
+    }
+}
+```
+
+### Pattern 2: URL Scope Filter (Pure Function)
+**What:** Static utility that checks if a URL passes scope filters (allowlist, blocklist, same-site). Pure function, unit-testable without mocks.
+**When to use:** Inside CrawlService loop before crawling each URL
+
+```java
+// In crawl/ package, similar to UrlNormalizer (static utility)
+public final class UrlScopeFilter {
+
+    public static boolean isAllowed(String url, String rootUrl, CrawlScope scope) {
+        if (!UrlNormalizer.isSameSite(rootUrl, url)) return false;
+        String path = extractPath(url);
+        // Block patterns take priority (negation patterns starting with !)
+        for (String pattern : scope.blockPatterns()) {
+            if (matchGlob(path, pattern)) return false;
+        }
+        // If allowPatterns exist, URL must match at least one
+        if (!scope.allowPatterns().isEmpty()) {
+            return scope.allowPatterns().stream().anyMatch(p -> matchGlob(path, p));
+        }
+        return true;
+    }
+
+    private static boolean matchGlob(String path, String pattern) {
+        PathMatcher matcher = FileSystems.getDefault()
+            .getPathMatcher("glob:" + pattern);
+        return matcher.matches(Path.of(path));
+    }
+}
+```
+
+### Pattern 3: Incremental Ingestion with Change Detection
+**What:** Wrap IngestionService to compare content hashes before processing
+**When to use:** During crawl-then-ingest flow
+
+The existing `IngestionState` entity and repository already support this pattern. The flow:
+1. Crawl page -> compute SHA-256 of markdown content
+2. Look up `IngestionState` by (sourceId, pageUrl)
+3. If hash matches -> skip (no re-chunking, no re-embedding)
+4. If hash differs or no record -> delete old chunks for that page URL, re-chunk, re-embed, update hash
+5. After crawl completes -> compare crawled URLs vs indexed URLs, delete orphaned chunks
+
+### Pattern 4: CrawlProgress Tracking (In-Memory + DB)
+**What:** Track crawl progress in a ConcurrentHashMap for real-time status, persist final state to Source entity
+**When to use:** `crawl_status` MCP tool reads from in-memory tracker during crawl; reads from Source after completion
+
+```java
+// In crawl/ package
+public record CrawlProgress(
+    UUID sourceId,
+    SourceStatus status,
+    int pagesCrawled,
+    int pagesSkipped,       // unchanged content hash
+    int pagesTotal,         // discovered URLs count (may grow during BFS)
+    int errors,
+    List<String> errorUrls, // URLs that failed
+    List<String> filteredUrls, // URLs excluded by scope
+    Instant startedAt
+) {}
+
+// CrawlProgressTracker manages ConcurrentHashMap<UUID, CrawlProgress>
+```
+
+### Pattern 5: llms.txt Discovery Cascade
+**What:** PageDiscoveryService tries llms.txt first, then sitemap.xml, then link crawl. Each level supplements previous.
+**When to use:** When adding a source or recrawling
+
+The current `PageDiscoveryService.discoverUrls()` tries sitemap first, falls back to link crawl. This extends to: llms.txt -> sitemap -> link crawl, with each level adding URLs not already discovered.
+
+### Anti-Patterns to Avoid
+- **Passing CrawlService the entire Source entity:** Pass only what's needed (URL, scope, sourceId). Keep the service testable.
+- **Storing progress in the database for real-time updates:** Use in-memory `ConcurrentHashMap` for active crawl status (polled by MCP tool). DB updates only on crawl start/complete/error.
+- **Implementing scheduled crawls "just in case":** Explicitly deferred. Only manual `recrawl_source`.
+- **Building a generic pipeline framework for crawl stages:** Sequential method calls in a service class are sufficient (consistent with existing IngestionService pattern).
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| SHA-256 hashing | Custom hash implementation | `java.security.MessageDigest.getInstance("SHA-256")` | Standard, battle-tested, 5 lines of code |
+| Glob pattern matching | Custom wildcard parser | `java.nio.file.FileSystems.getDefault().getPathMatcher("glob:...")` | JDK built-in, handles `*`, `**`, `?`, `[...]` |
+| llms.txt Markdown parsing | Full Markdown parser for llms.txt | Simple line-by-line parsing with regex | llms.txt is trivially structured: H1, H2 headers, and `- [name](url)` links |
+| Metadata-based chunk deletion | Custom SQL DELETE queries | `embeddingStore.removeAll(metadataKey("source_url").isEqualTo(url))` | Already proven in PreChunkedImporter |
+| URL normalization | New normalizer | Existing `UrlNormalizer.normalize()` | Already handles fragments, tracking params, trailing slashes |
+
+**Key insight:** The codebase already contains most building blocks. Phase 7 is primarily about orchestration and connecting existing pieces, not building new fundamental capabilities.
+
+## Common Pitfalls
+
+### Pitfall 1: PathMatcher and URL Paths
+**What goes wrong:** `java.nio.file.PathMatcher` operates on `java.nio.file.Path` objects, which are filesystem paths. URL paths like `/docs/api/v2` work fine, but patterns with query strings or fragments will not match correctly.
+**Why it happens:** PathMatcher was designed for file systems, not URLs. It handles `/` as separator correctly, but edge cases exist.
+**How to avoid:** Extract only the path component from the URL before matching. Always normalize URLs first via `UrlNormalizer.normalize()` before scope filtering. Unit test edge cases: root path `/`, paths with dots, paths with encoded characters.
+**Warning signs:** Patterns that "should match" failing in tests, or URLs with query strings not being filtered correctly.
+
+### Pitfall 2: Race Conditions in Progress Tracking
+**What goes wrong:** Crawl runs on virtual thread, MCP tool reads progress from another thread. Without thread safety, progress can show stale or inconsistent data.
+**Why it happens:** Virtual threads in Spring Boot 3.5 mean multiple concurrent requests. `ConcurrentHashMap` is safe for individual operations but compound read-modify-write needs care.
+**How to avoid:** Use `ConcurrentHashMap` with `AtomicReference<CrawlProgress>` or make `CrawlProgress` immutable and replace entirely via `ConcurrentHashMap.put()`. Avoid partial updates.
+**Warning signs:** Tests that pass in isolation but fail under concurrent access, or progress showing 0 after crawl is complete.
+
+### Pitfall 3: Orphaned Chunk Deletion During Incremental Crawl
+**What goes wrong:** After a recrawl, pages that were removed from the site still have chunks in pgvector. Or worse, deletion happens mid-crawl before verifying all pages.
+**Why it happens:** Deleted page detection requires comparing crawled URLs against indexed URLs, but this must happen after the entire crawl completes (not during).
+**How to avoid:** Two-phase approach: (1) crawl all pages, tracking which URLs were visited, (2) after crawl completes, query `ingestion_state` for all page URLs belonging to this source, delete chunks for any URL not in the crawled set. User decision explicitly specifies this post-crawl approach.
+**Warning signs:** Chunks remaining for deleted pages, or chunks being prematurely deleted during a partial crawl failure.
+
+### Pitfall 4: llms-full.txt Hybrid Ingestion Complexity
+**What goes wrong:** Ingesting llms-full.txt directly AND crawling individual pages creates duplicate chunks for pages covered by both.
+**Why it happens:** llms-full.txt contains concatenated page content, but the system also crawls those same pages individually.
+**How to avoid:** Track which page URLs are covered by llms-full.txt content. When crawling additional pages, skip any URL whose content is already ingested from llms-full.txt. The key is treating llms-full.txt as the primary source and only filling gaps via crawl.
+**Warning signs:** Duplicate chunks in search results, or search quality degradation from duplicated content.
+
+### Pitfall 5: EmbeddingStore.removeAll() Performance with Metadata Filters
+**What goes wrong:** Deleting chunks by `source_url` metadata is O(n) on the entire embedding store if not indexed properly.
+**Why it happens:** JSONB metadata queries without a proper index can be slow.
+**How to avoid:** The `document_chunks` table already has an index on `source_id` (B-tree). For per-page deletion, use `source_url` metadata filter via LangChain4j's `removeAll(Filter)`. If performance becomes an issue, consider adding a GIN index on the metadata JSONB column. For now, the existing setup should be sufficient for typical documentation sites (hundreds to low thousands of pages).
+**Warning signs:** Slow recrawl operations, especially the delete phase.
+
+### Pitfall 6: Source Entity Schema Changes
+**What goes wrong:** Adding new columns to the `sources` table (e.g., scope patterns, max_pages config) without a Flyway migration causes Hibernate validation failures or runtime errors.
+**Why it happens:** `ddl-auto=none` means Hibernate does not create or modify schema -- Flyway is the source of truth.
+**How to avoid:** Create a V2 Flyway migration for any schema changes. Add new columns with sensible defaults so existing data is not affected.
+**Warning signs:** `SchemaManagementException` on startup, or null values in new columns for existing sources.
+
+## Code Examples
+
+### SHA-256 Content Hashing (JDK built-in)
+```java
+// Source: java.security.MessageDigest (JDK 21)
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public final class ContentHasher {
+    private ContentHasher() {}
+
+    public static String sha256(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(content.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}
+```
+
+### Glob Pattern Matching on URL Paths (JDK built-in)
+```java
+// Source: java.nio.file (JDK 21)
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+
+// Match URL path against glob pattern
+String urlPath = "/docs/api/reference";
+PathMatcher matcher = FileSystems.getDefault()
+    .getPathMatcher("glob:/docs/**");
+boolean matches = matcher.matches(Path.of(urlPath)); // true
+
+// Blocklist pattern (convention: ! prefix stripped before matching)
+PathMatcher blockMatcher = FileSystems.getDefault()
+    .getPathMatcher("glob:/docs/archive/**");
+boolean blocked = blockMatcher.matches(Path.of(urlPath)); // false
+```
+
+### LangChain4j Chunk Deletion by Metadata
+```java
+// Source: Already used in PreChunkedImporter.java
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+
+// Delete all chunks for a specific page URL
+embeddingStore.removeAll(
+    metadataKey("source_url").isEqualTo("https://docs.spring.io/boot/configuration")
+);
+```
+
+### IngestionState Lookup for Change Detection
+```java
+// Source: Existing IngestionStateRepository.java
+Optional<IngestionState> existing = ingestionStateRepository
+    .findBySourceIdAndPageUrl(sourceId, normalizedUrl);
+
+String newHash = ContentHasher.sha256(crawlResult.markdown());
+
+if (existing.isPresent() && existing.get().getContentHash().equals(newHash)) {
+    // Content unchanged -- skip re-processing
+    return;
+}
+
+// Content changed or new page -- re-process
+// 1. Delete old chunks for this page
+embeddingStore.removeAll(metadataKey("source_url").isEqualTo(normalizedUrl));
+// 2. Re-chunk and re-embed
+ingestionService.ingestPage(crawlResult.markdown(), normalizedUrl, Instant.now().toString());
+// 3. Update hash
+if (existing.isPresent()) {
+    existing.get().setContentHash(newHash);
+    existing.get().setLastIngestedAt(Instant.now());
+    ingestionStateRepository.save(existing.get());
+} else {
+    ingestionStateRepository.save(new IngestionState(sourceId, normalizedUrl, newHash));
+}
+```
+
+### llms.txt Parsing (Line-by-Line)
+```java
+// Parse llms.txt format: extract URLs from markdown links
+// Format: - [Title](https://url): Optional description
+private static final Pattern LINK_PATTERN =
+    Pattern.compile("^-\\s*\\[([^\\]]+)\\]\\(([^)]+)\\)");
+
+public List<String> parseUrls(String llmsTxtContent) {
+    return llmsTxtContent.lines()
+        .map(LINK_PATTERN::matcher)
+        .filter(Matcher::find)
+        .map(m -> m.group(2))  // Extract URL
+        .toList();
+}
+```
+
+### CrawlService with Depth Tracking
+```java
+// Depth tracking during BFS crawl
+// Current: queue is LinkedHashSet<String> (URL only)
+// New: queue tracks (url, depth) pairs
+record QueueEntry(String url, int depth) {}
+
+// In the crawl loop:
+while (!queue.isEmpty() && results.size() < scope.maxPages()) {
+    QueueEntry entry = dequeue(queue);
+    if (scope.maxDepth() != null && entry.depth() > scope.maxDepth()) {
+        continue; // Skip URLs beyond max depth
+    }
+    // ... crawl and process ...
+    if (followLinks) {
+        for (String link : discoveredLinks) {
+            queue.add(new QueueEntry(link, entry.depth() + 1));
+        }
+    }
+}
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Crawl4AI deep_crawl_strategy for BFS | Alexandria manages own BFS loop, Crawl4AI for single-page rendering | Phase 3 (established pattern) | All scope/depth logic is in Java, not delegated to Crawl4AI |
+| Full re-crawl every time | Incremental crawl with content hashing | Phase 7 (this phase) | Significantly reduces re-processing for large doc sites |
+| No llms.txt support | llms.txt/llms-full.txt as discovery + content source | Phase 7 (this phase) | Aligns with emerging documentation standard |
+
+**Key architectural fact:** Alexandria's CrawlService already does BFS link-crawling in Java, calling Crawl4AI's `/crawl` REST endpoint for single-page rendering only. This means max_depth, scope filtering, and page limits are all Alexandria-side concerns. Crawl4AI's deep_crawl_strategy (BFS/DFS) is a Python SDK feature that does not apply to the REST API usage.
+
+## Existing Codebase Assets for Phase 7
+
+### Already Built (ready to use)
+| Asset | Location | What It Does | Phase 7 Usage |
+|-------|----------|-------------|---------------|
+| `IngestionState` entity | `ingestion/IngestionState.java` | Stores (sourceId, pageUrl, contentHash, lastIngestedAt) | Change detection for incremental crawl |
+| `IngestionStateRepository` | `ingestion/IngestionStateRepository.java` | `findBySourceIdAndPageUrl()` | Look up existing hash for a page |
+| `ingestion_state` table | `V1__initial_schema.sql` | DB table with UNIQUE(source_id, page_url) | Persist content hashes |
+| `CrawlService.crawlSite()` | `crawl/CrawlService.java` | BFS crawl with maxPages limit | Extend with depth tracking and scope filtering |
+| `PageDiscoveryService` | `crawl/PageDiscoveryService.java` | Sitemap-first, fallback to link crawl | Add llms.txt as highest-priority discovery |
+| `SitemapParser` | `crawl/SitemapParser.java` | Fetches/parses sitemap.xml | Pattern to follow for llms.txt fetching |
+| `UrlNormalizer` | `crawl/UrlNormalizer.java` | URL normalization and same-site check | Used before scope filtering |
+| `McpToolService` stubs | `mcp/McpToolService.java` | `crawlStatus()`, `recrawlSource()`, `addSource()` stubs | Replace stubs with real implementations |
+| `SourceStatus` enum | `source/SourceStatus.java` | PENDING, CRAWLING, INDEXED, UPDATING, ERROR | Already has UPDATING state for recrawls |
+| `EmbeddingStore.removeAll(Filter)` | Used in `PreChunkedImporter.java` | Delete chunks by metadata filter | Delete old chunks for changed/deleted pages |
+| `SourceBuilder` fixture | `fixture/SourceBuilder.java` | Test builder for Source entity | Extend with new fields (scope config) |
+
+### Needs Building
+| Component | Package | Purpose |
+|-----------|---------|---------|
+| `CrawlScope` record | `crawl/` | Immutable scope config (patterns, maxDepth, maxPages) |
+| `UrlScopeFilter` | `crawl/` | Static utility to filter URLs against scope patterns |
+| `ContentHasher` | `crawl/` or `ingestion/` | SHA-256 utility for content hashing |
+| `LlmsTxtParser` | `crawl/` | Fetch and parse llms.txt/llms-full.txt |
+| `CrawlProgressTracker` | `crawl/` | In-memory progress tracking (ConcurrentHashMap) |
+| `CrawlOrchestrator` (or extend CrawlService) | `crawl/` | Orchestrate: discover -> crawl -> ingest -> cleanup |
+| V2 Flyway migration | `db/migration/` | Add scope columns to sources table |
+| Source entity updates | `source/Source.java` | New fields: allowPatterns, blockPatterns, maxPages, maxDepth |
+| IngestionStateRepository extensions | `ingestion/` | `findAllBySourceId()`, `deleteBySourceIdAndPageUrlNotIn()` |
+| DocumentChunkRepository extensions | `document/` | `deleteBySourceId()` or use EmbeddingStore filter |
+
+## Discretion Recommendations
+
+### Progress Reporting Format (Claude's Discretion)
+**Recommendation:** Structured text format for `crawl_status` output:
+
+```
+Source: Spring Boot Docs (https://docs.spring.io/boot)
+Status: CRAWLING
+Progress: 42/120 pages crawled (35%)
+Skipped: 15 pages (unchanged content)
+Errors: 2 pages failed
+  - https://docs.spring.io/boot/old-page: 404 Not Found
+  - https://docs.spring.io/boot/broken: Connection timeout
+Filtered: 5 URLs excluded by scope
+  - https://docs.spring.io/boot/archive/v1: blocked by !/docs/archive/**
+Started: 2026-02-20T10:30:00Z
+Elapsed: 3m 45s
+```
+
+For completed crawls, show summary:
+```
+Source: Spring Boot Docs (https://docs.spring.io/boot)
+Status: INDEXED
+Last crawl: 2026-02-20T10:33:45Z
+Pages: 103 crawled, 15 skipped (unchanged), 2 errors
+Chunks: 1,247 total
+```
+
+### Hash Storage Mechanism (Claude's Discretion)
+**Recommendation:** Use the existing `ingestion_state` table (separate tracking table). It already exists with the right schema: `(source_id, page_url, content_hash, last_ingested_at)` with a unique constraint on `(source_id, page_url)`. No need for a column on `document_chunks` -- the separate table cleanly separates concerns and is already built.
+
+Additional repository methods needed:
+- `List<IngestionState> findAllBySourceId(UUID sourceId)` -- for deleted page detection
+- `void deleteAllBySourceId(UUID sourceId)` -- for full recrawl reset
+- `void deleteAllBySourceIdAndPageUrlNotIn(UUID sourceId, Collection<String> pageUrls)` -- for orphaned page cleanup
+
+### Glob Pattern Matching Library (Claude's Discretion)
+**Recommendation:** Use JDK's `java.nio.file.PathMatcher` with `glob:` syntax. Zero dependencies, handles `*`, `**`, `?`, `[...]` correctly. The key insight: extract URL path before matching (strip scheme/host/query). This is a pure utility function, easily unit-tested.
+
+Caveat: `PathMatcher` operates on `java.nio.file.Path` objects. URL paths work correctly as they use `/` as separator, same as POSIX file paths. Edge case to test: root path `/`, encoded characters like `%20`.
+
+### llms.txt Parsing Implementation (Claude's Discretion)
+**Recommendation:** Simple line-by-line parser with regex. The llms.txt format is intentionally simple Markdown:
+- H1: project name (required)
+- Blockquote: summary (optional)
+- H2: section headers (optional)
+- List items: `- [Title](URL): description` (the URLs we extract)
+
+For llms-full.txt: Treat the entire file content as a single large Markdown document to be chunked and ingested directly (via MarkdownChunker). Track which URLs are covered by parsing any H2/H3 headers that match page titles to URLs from llms.txt.
+
+**Parsing approach:** Regex for URL extraction (`Pattern.compile("^-\\s*\\[([^\\]]+)\\]\\(([^)]+)\\)")`), standard HTTP GET for fetching. Reuse `RestClient.Builder` pattern from `SitemapParser`.
+
+## Open Questions
+
+1. **Source schema extension for scope config**
+   - What we know: Source entity needs new fields for allowPatterns, blockPatterns, maxPages, maxDepth, and optionally llmsTxtUrl
+   - What's unclear: Whether to store patterns as comma-separated string, JSON array, or separate table
+   - Recommendation: Store as JSON array in a single JSONB column (PostgreSQL native JSON support, no migration for each pattern change). Two columns: `scope_config JSONB` containing `{"allow": [...], "block": [...], "max_depth": N, "max_pages": N}`, or individual columns. Individual columns are simpler for JPA mapping.
+
+2. **add_source triggering crawl orchestration**
+   - What we know: add_source currently just saves a Source in PENDING status (stub)
+   - What's unclear: Whether Phase 6 (Source Management) will have already connected add_source to CrawlService, or if Phase 7 must do this
+   - Recommendation: Assume Phase 7 must handle the full orchestration: add_source -> discover pages -> crawl -> ingest -> update source status. If Phase 6 already handles basic crawl triggering, Phase 7 extends it with scope/incremental/llms.txt support.
+
+3. **llms-full.txt page URL mapping**
+   - What we know: llms-full.txt is a single concatenated Markdown file; we need to track which "pages" it covers
+   - What's unclear: How to reliably map content sections in llms-full.txt back to individual page URLs
+   - Recommendation: Use the URL list from llms.txt as the authoritative mapping. Pages listed in llms.txt are considered "covered" if their content appears in llms-full.txt. For ingestion, chunk the entire llms-full.txt as one document with the site root as source_url, and skip crawling pages whose URLs appear in the llms.txt listing. This is simpler than trying to split llms-full.txt into per-page segments.
+
+4. **ConcurrentHashMap cleanup for progress tracking**
+   - What we know: In-memory progress tracking needs cleanup after crawls complete
+   - What's unclear: How long to keep completed crawl progress in memory
+   - Recommendation: Keep completed crawl progress for 1 hour (configurable), then evict. This allows checking status shortly after completion. For historical data, the Source entity stores lastCrawledAt, chunkCount, and status.
+
+## Sources
+
+### Primary (HIGH confidence)
+- Existing codebase: `CrawlService.java`, `IngestionState.java`, `McpToolService.java`, `V1__initial_schema.sql` -- direct code reading
+- JDK 21 documentation: `java.security.MessageDigest`, `java.nio.file.PathMatcher`, `java.nio.file.FileSystems`
+- LangChain4j PgVectorEmbeddingStore: `removeAll(Filter)` method verified in existing `PreChunkedImporter.java`
+
+### Secondary (MEDIUM confidence)
+- llms.txt specification: [llmstxt.org](https://llmstxt.org/) -- format is simple and stable
+- Crawl4AI REST API: [docs.crawl4ai.com](https://docs.crawl4ai.com/api/parameters/) -- confirms deep crawling is Python SDK, REST is single-page
+- SHA-256 in Java: [Baeldung guide](https://www.baeldung.com/sha-256-hashing-java) -- standard MessageDigest pattern
+
+### Tertiary (LOW confidence)
+- llms-full.txt specification: No formal spec exists at llmstxt.org. The "full" variant is a community convention (concatenated Markdown), not an official standard. Implementation should be flexible.
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH -- no new dependencies, all JDK/existing libraries
+- Architecture: HIGH -- extensions to existing patterns, not new architectural paradigms
+- Pitfalls: HIGH -- identified from direct codebase analysis (known integration points)
+- llms.txt parsing: MEDIUM -- format is simple but llms-full.txt hybrid ingestion has design decisions
+- Progress tracking concurrency: MEDIUM -- virtual threads interaction needs careful testing
+
+**Research date:** 2026-02-20
+**Valid until:** 2026-03-20 (30 days -- stable domain, no fast-moving dependencies)

--- a/.planning/phases/07-crawl-operations/07-VERIFICATION.md
+++ b/.planning/phases/07-crawl-operations/07-VERIFICATION.md
@@ -1,0 +1,158 @@
+---
+phase: 07-crawl-operations
+verified: 2026-02-20T10:16:42Z
+status: passed
+score: 17/17 must-haves verified
+re_verification: false
+---
+
+# Phase 7: Crawl Operations Verification Report
+
+**Phase Goal:** Users have full operational control over crawling -- scope limits, incremental updates, scheduled recrawls, progress monitoring, and llms.txt support
+**Verified:** 2026-02-20T10:16:42Z
+**Status:** passed
+**Re-verification:** No -- initial verification
+
+---
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | CrawlScope record holds immutable scope config (allow/block patterns, max depth, max pages) | VERIFIED | `CrawlScope.java` lines 11-21: record with List.copyOf() compact constructor |
+| 2 | UrlScopeFilter correctly filters URLs by glob patterns, block takes priority | VERIFIED | `UrlScopeFilter.java` lines 34-70: isSameSite check, block loop first, then allow |
+| 3 | ContentHasher produces deterministic SHA-256 hex strings | VERIFIED | `ContentHasher.java` lines 24-33: MessageDigest + HexFormat |
+| 4 | LlmsTxtParser extracts URLs from Markdown-link lists in llms.txt format | VERIFIED | `LlmsTxtParser.java` lines 54-71: Pattern.compile regex, line-by-line extraction |
+| 5 | LlmsTxtParser handles both llms.txt (URL lists) and llms-full.txt (raw content) | VERIFIED | `LlmsTxtParser.java` lines 130-143: parse() distinguishes via isLlmsTxtContent() heuristic |
+| 6 | Source entity stores scope config persisted via V2 Flyway migration | VERIFIED | `V2__source_scope_columns.sql` adds allow_patterns/block_patterns/max_depth/max_pages; `Source.java` has matching @Column annotations |
+| 7 | IngestionStateRepository supports querying all states and deleting orphaned pages | VERIFIED | `IngestionStateRepository.java`: findAllBySourceId, deleteAllBySourceId, deleteAllBySourceIdAndPageUrlNotIn |
+| 8 | CrawlProgressTracker provides thread-safe in-memory progress tracking | VERIFIED | `CrawlProgressTracker.java` line 25: ConcurrentHashMap; compute() used for atomic updates |
+| 9 | PageDiscoveryService tries llms-full.txt first, then llms.txt, then sitemap, then link crawl | VERIFIED | `PageDiscoveryService.java` lines 43-67: 4-level cascade in discoverUrls() |
+| 10 | CrawlService applies scope filtering during BFS crawl | VERIFIED | `CrawlService.java` lines 153, 257: UrlScopeFilter.isAllowed() called in seedQueue and enqueueDiscoveredLinks |
+| 11 | CrawlService performs incremental crawl: skips unchanged pages, re-processes changed pages | VERIFIED | `CrawlService.java` lines 212-242: ingestIncremental() compares ContentHasher.sha256() against stored hash |
+| 12 | CrawlService detects and cleans up deleted pages post-crawl | VERIFIED | `CrawlService.java` lines 276-296: cleanupDeletedPages() finds orphaned states and deletes chunks |
+| 13 | CrawlService handles llms-full.txt hybrid ingestion | VERIFIED | `CrawlService.java` lines 74-85: ingests direct content, tracks covered URLs, skips during BFS |
+| 14 | CrawlService tracks progress via CrawlProgressTracker | VERIFIED | `CrawlService.java` lines 97,119,133,137,185-203,260: startCrawl/recordPageCrawled/recordPageSkipped/recordError/recordFiltered/completeCrawl/failCrawl |
+| 15 | add_source MCP tool accepts scope parameters and triggers async crawl | VERIFIED | `McpToolService.java` lines 127-158: 7-param @Tool method, CrawlScope.fromSource(), Thread.startVirtualThread |
+| 16 | crawl_status MCP tool returns real-time progress for active crawls, summary for completed | VERIFIED | `McpToolService.java` lines 182-204: progressTracker.getProgress() -> formatActiveProgress or formatCompletedSummary |
+| 17 | recrawl_source MCP tool triggers incremental/full recrawl with optional scope override | VERIFIED | `McpToolService.java` lines 211-254: full flag calls ingestionService.clearIngestionState(), buildRecrawlScope() for overrides |
+
+**Score:** 17/17 truths verified
+
+---
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `src/main/java/dev/alexandria/crawl/CrawlScope.java` | Immutable scope config record | VERIFIED | Contains `record CrawlScope`, `withDefaults()`, `fromSource()` factory |
+| `src/main/java/dev/alexandria/crawl/UrlScopeFilter.java` | Static URL filtering utility | VERIFIED | Contains `isAllowed(String, String, CrawlScope)` |
+| `src/main/java/dev/alexandria/crawl/ContentHasher.java` | SHA-256 hashing utility | VERIFIED | Contains `sha256(String)` |
+| `src/main/java/dev/alexandria/crawl/LlmsTxtParser.java` | llms.txt/llms-full.txt parser | VERIFIED | Contains `parseUrls`, `isLlmsTxtContent`, `parse`, nested `LlmsTxtResult` record |
+| `src/main/resources/db/migration/V2__source_scope_columns.sql` | Schema migration | VERIFIED | Contains `ALTER TABLE sources` with all 5 scope columns |
+| `src/main/java/dev/alexandria/source/Source.java` | Source entity with scope fields | VERIFIED | Contains `allowPatterns`, `getBlockPatternList()`, `getAllowPatternList()` |
+| `src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java` | Thread-safe progress tracker | VERIFIED | Contains `ConcurrentHashMap` field, all lifecycle methods |
+| `src/main/java/dev/alexandria/crawl/CrawlProgress.java` | Immutable progress snapshot record | VERIFIED | Contains `record CrawlProgress` with nested `Status` enum |
+| `src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java` | Extended repository | VERIFIED | Contains `findAllBySourceId`, `deleteAllBySourceId`, `deleteAllBySourceIdAndPageUrlNotIn` |
+| `src/main/java/dev/alexandria/crawl/PageDiscoveryService.java` | Discovery with llms.txt cascade | VERIFIED | Contains `llmsTxt` logic, `LLMS_TXT`/`LLMS_FULL_TXT` enum values |
+| `src/main/java/dev/alexandria/crawl/CrawlService.java` | Scope/incremental/progress orchestrator | VERIFIED | Contains `CrawlScope` usage, incremental logic, progress calls |
+| `src/main/java/dev/alexandria/ingestion/IngestionService.java` | Ingestion with chunk deletion | VERIFIED | Contains `deleteChunksForUrl`, `clearIngestionState`, `IngestResult` record |
+| `src/main/java/dev/alexandria/mcp/McpToolService.java` | Real MCP tool implementations | VERIFIED | Contains `crawlService.crawlSite`, no stubs, 6 @Tool methods |
+| `src/test/java/dev/alexandria/crawl/UrlScopeFilterTest.java` | URL scope filtering tests | VERIFIED | 8 @Test methods, 84 lines |
+| `src/test/java/dev/alexandria/crawl/ContentHasherTest.java` | Content hashing tests | VERIFIED | 4 @Test methods, 38 lines |
+| `src/test/java/dev/alexandria/crawl/LlmsTxtParserTest.java` | llms.txt parser tests | VERIFIED | 11 @Test methods, 251 lines |
+| `src/test/java/dev/alexandria/crawl/CrawlProgressTrackerTest.java` | Progress tracker tests | VERIFIED | 9 @Test methods, 111 lines |
+| `src/test/java/dev/alexandria/crawl/CrawlServiceTest.java` | Crawl orchestrator tests | VERIFIED | 18 @Test methods, 457 lines |
+| `src/test/java/dev/alexandria/mcp/McpToolServiceTest.java` | MCP tool tests | VERIFIED | 30 @Test methods, 522 lines |
+
+---
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `UrlScopeFilter.java` | `CrawlScope.java` | `isAllowed` takes CrawlScope parameter | WIRED | Line 34: `isAllowed(String url, String rootUrl, CrawlScope scope)` |
+| `UrlScopeFilter.java` | `UrlNormalizer.java` | `UrlNormalizer.isSameSite` call | WIRED | Line 42: `UrlNormalizer.isSameSite(rootUrl, url)` |
+| `LlmsTxtParser.java` | llms.txt format | `Pattern.compile` regex extraction | WIRED | Line 30-31: `Pattern.compile("\\[([^\\]]+)\\]\\(([^)]+)\\)")` |
+| `Source.java` | `V2__source_scope_columns.sql` | JPA @Column mappings match Flyway columns | WIRED | allow_patterns, block_patterns, max_depth, max_pages all match migration SQL |
+| `CrawlProgressTracker.java` | `CrawlProgress.java` | `ConcurrentHashMap<UUID, CrawlProgress>` | WIRED | Line 25: field declaration; all update methods use computeIfPresent |
+| `PageDiscoveryService.java` | `LlmsTxtParser.java` | `LlmsTxtParser.parseUrls()` / `LlmsTxtParser.parse()` | WIRED | Lines 77, 99: direct static calls |
+| `CrawlService.java` | `UrlScopeFilter.java` | `UrlScopeFilter.isAllowed()` in BFS loop | WIRED | Lines 153, 257: called in seedQueue and enqueueDiscoveredLinks |
+| `CrawlService.java` | `CrawlProgressTracker.java` | `progressTracker.record*` calls | WIRED | Lines 97,119,133,137,185,187,197,203,260: all lifecycle events tracked |
+| `CrawlService.java` | `IngestionService.java` | `ingestionService.ingestPage()` / `deleteChunksForUrl()` | WIRED | Lines 78, 224, 227, 293: incremental ingest and chunk deletion |
+| `McpToolService.java` | `CrawlService.java` | `crawlService.crawlSite(sourceId, url, scope)` | WIRED | Line 262: called in virtual thread dispatch |
+| `McpToolService.java` | `CrawlProgressTracker.java` | `progressTracker.getProgress(uuid)` | WIRED | Line 193: in crawlStatus handler |
+| `McpToolService.java` | `Source.java` | `CrawlScope.fromSource(source)` | WIRED | Lines 149, 280: scope built from Source entity |
+
+---
+
+### Requirements Coverage
+
+| Requirement | Description | Status | Notes |
+|-------------|-------------|--------|-------|
+| CRWL-03 | User can control crawl scope (URL pattern allowlist/blocklist, max depth, max pages) | SATISFIED | CrawlScope record, UrlScopeFilter, Source scope fields, add_source/recrawl_source scope params |
+| CRWL-06 | System performs incremental/delta crawls -- only re-processes pages whose content hash has changed | SATISFIED | ContentHasher + ingestIncremental() in CrawlService + IngestionStateRepository |
+| CRWL-07 | User can schedule periodic recrawls (interval-based) | DEFERRED -- SATISFIED AS MANUAL | No automatic scheduling; plan explicitly decided CRWL-07 is satisfied by manual recrawl_source tool. Scheduling not implemented -- acceptable per plan decision |
+| CRWL-09 | User can check crawl progress via MCP tool crawl_status | SATISFIED | CrawlProgressTracker + crawl_status @Tool in McpToolService |
+| CRWL-10 | User can trigger a recrawl via MCP tool recrawl_source | SATISFIED | recrawl_source @Tool with full/incremental modes and scope overrides |
+| CRWL-11 | System can ingest llms.txt and llms-full.txt as page discovery mechanism | SATISFIED | LlmsTxtParser, PageDiscoveryService 4-level cascade, llms-full.txt hybrid ingestion |
+
+**Note on CRWL-07:** The requirement as written ("interval-based scheduling") is not implemented -- there are no @Scheduled annotations or timer infrastructure. The plan explicitly categorized this as "satisfied as deferred" with manual recrawl_source as the delivery. REQUIREMENTS.md shows CRWL-07 still marked Pending. This is an accepted scope decision documented in the plan, not a gap.
+
+---
+
+### Anti-Patterns Found
+
+None. No TODO/FIXME/placeholder comments detected in phase 7 production files. No stub return values in McpToolService. All @Tool methods contain real orchestration logic.
+
+---
+
+### Test Suite Health
+
+- **Total tests:** 211 passed, 0 failed, 0 skipped
+- All 80+ new unit tests from phase 7 pass
+- No regressions in existing suite
+
+---
+
+### Human Verification Required
+
+#### 1. Async Crawl Status Visibility
+
+**Test:** Call add_source via MCP, then immediately call crawl_status with the returned source ID while the crawl is running.
+**Expected:** crawl_status returns real-time progress (pages crawled/total, not just "CRAWLING" status).
+**Why human:** Virtual thread timing is non-deterministic; integration requires a running Crawl4AI sidecar.
+
+#### 2. llms.txt Discovery Cascade Order
+
+**Test:** Add a source for a site that has llms.txt but no llms-full.txt. Verify PageDiscoveryService uses LLMS_TXT method.
+**Expected:** Source is indexed via llms.txt URLs, not sitemap or link crawl.
+**Why human:** Requires a live documentation site with llms.txt and actual HTTP requests.
+
+#### 3. Incremental Recrawl Skipping
+
+**Test:** Add a source, wait for indexing. Call recrawl_source. Check crawl_status for skipped count > 0.
+**Expected:** Pages with unchanged content have pagesSkipped > 0, pagesCrawled reflects only changed pages.
+**Why human:** Requires live crawl infrastructure and two sequential crawl runs.
+
+#### 4. Full Recrawl State Reset
+
+**Test:** Call recrawl_source with full=true. Verify all pages are re-indexed regardless of content hash.
+**Expected:** pagesSkipped = 0 for a full recrawl; all pages re-chunked.
+**Why human:** Requires verifying IngestionState table is cleared before crawl, needs integration environment.
+
+---
+
+## Summary
+
+All 17 observable truths verified. All 19 required artifacts exist and are substantively implemented. All 12 key links wired. 211/211 tests pass. No anti-patterns found.
+
+CRWL-07 (interval scheduling) is the only requirement not fully implemented as written, but this was an explicit scope decision in the plan -- manual recrawl_source satisfies the user-facing need.
+
+The phase goal is achieved: users have full operational control over crawling via scope limits (CRWL-03), incremental updates (CRWL-06), progress monitoring (CRWL-09), manual recrawls (CRWL-10), and llms.txt support (CRWL-11).
+
+---
+_Verified: 2026-02-20T10:16:42Z_
+_Verifier: Claude (gsd-verifier)_

--- a/src/main/java/dev/alexandria/crawl/ContentHasher.java
+++ b/src/main/java/dev/alexandria/crawl/ContentHasher.java
@@ -1,0 +1,22 @@
+package dev.alexandria.crawl;
+
+/**
+ * Static utility for computing SHA-256 content hashes.
+ * Used for incremental change detection during crawling.
+ */
+public final class ContentHasher {
+
+    private ContentHasher() {
+        // utility class
+    }
+
+    /**
+     * Compute the SHA-256 hash of the given content.
+     *
+     * @param content the content to hash
+     * @return lowercase hex string of the SHA-256 hash
+     */
+    public static String sha256(String content) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/ContentHasher.java
+++ b/src/main/java/dev/alexandria/crawl/ContentHasher.java
@@ -1,5 +1,10 @@
 package dev.alexandria.crawl;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
 /**
  * Static utility for computing SHA-256 content hashes.
  * Used for incremental change detection during crawling.
@@ -17,6 +22,12 @@ public final class ContentHasher {
      * @return lowercase hex string of the SHA-256 hash
      */
     public static String sha256(String content) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(content.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
     }
 }

--- a/src/main/java/dev/alexandria/crawl/CrawlProgress.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlProgress.java
@@ -1,0 +1,48 @@
+package dev.alexandria.crawl;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Immutable snapshot of an active crawl's progress.
+ *
+ * <p>Created and updated by {@link CrawlProgressTracker} during crawl execution.
+ * Each mutation produces a new record (value semantics for thread safety).
+ *
+ * @param sourceId     the source being crawled
+ * @param status       current crawl status (CRAWLING, COMPLETED, FAILED)
+ * @param pagesCrawled number of pages successfully crawled
+ * @param pagesSkipped number of pages skipped due to unchanged content hash
+ * @param pagesTotal   total discovered URLs (may grow during BFS)
+ * @param errors       number of pages that failed to crawl
+ * @param errorUrls    URLs that failed during crawl
+ * @param filteredUrls URLs excluded by scope filtering
+ * @param startedAt    when the crawl started
+ */
+public record CrawlProgress(
+        java.util.UUID sourceId,
+        Status status,
+        int pagesCrawled,
+        int pagesSkipped,
+        int pagesTotal,
+        int errors,
+        List<String> errorUrls,
+        List<String> filteredUrls,
+        Instant startedAt
+) {
+
+    public CrawlProgress {
+        errorUrls = errorUrls == null ? List.of() : List.copyOf(errorUrls);
+        filteredUrls = filteredUrls == null ? List.of() : List.copyOf(filteredUrls);
+    }
+
+    /**
+     * Crawl progress status, independent of {@link dev.alexandria.source.SourceStatus}
+     * to avoid a package cycle between crawl and source packages.
+     */
+    public enum Status {
+        CRAWLING,
+        COMPLETED,
+        FAILED
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlProgressTracker.java
@@ -1,0 +1,219 @@
+package dev.alexandria.crawl;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Thread-safe in-memory tracker for active crawl progress.
+ *
+ * <p>Maintains a {@link ConcurrentHashMap} of {@link CrawlProgress} snapshots keyed by source ID.
+ * Each update atomically reads the current state, creates a new immutable record with the
+ * updated field, and writes it back using {@code compute()}.
+ *
+ * <p>This is a singleton Spring bean. Progress data is transient (in-memory only) and lost
+ * on restart. For persistent crawl status, use the {@link dev.alexandria.source.Source} entity.
+ */
+@Component
+public class CrawlProgressTracker {
+
+    private final ConcurrentHashMap<UUID, CrawlProgress> activeCrawls = new ConcurrentHashMap<>();
+
+    /**
+     * Start tracking a new crawl.
+     *
+     * @param sourceId     the source being crawled
+     * @param initialTotal initial count of discovered URLs
+     */
+    public void startCrawl(UUID sourceId, int initialTotal) {
+        activeCrawls.put(sourceId, new CrawlProgress(
+                sourceId,
+                CrawlProgress.Status.CRAWLING,
+                0,
+                0,
+                initialTotal,
+                0,
+                List.of(),
+                List.of(),
+                Instant.now()
+        ));
+    }
+
+    /**
+     * Record that a page was successfully crawled.
+     *
+     * @param sourceId the source being crawled
+     */
+    public void recordPageCrawled(UUID sourceId) {
+        activeCrawls.computeIfPresent(sourceId, (id, progress) ->
+                new CrawlProgress(
+                        progress.sourceId(),
+                        progress.status(),
+                        progress.pagesCrawled() + 1,
+                        progress.pagesSkipped(),
+                        progress.pagesTotal(),
+                        progress.errors(),
+                        progress.errorUrls(),
+                        progress.filteredUrls(),
+                        progress.startedAt()
+                )
+        );
+    }
+
+    /**
+     * Record that a page was skipped due to unchanged content hash.
+     *
+     * @param sourceId the source being crawled
+     */
+    public void recordPageSkipped(UUID sourceId) {
+        activeCrawls.computeIfPresent(sourceId, (id, progress) ->
+                new CrawlProgress(
+                        progress.sourceId(),
+                        progress.status(),
+                        progress.pagesCrawled(),
+                        progress.pagesSkipped() + 1,
+                        progress.pagesTotal(),
+                        progress.errors(),
+                        progress.errorUrls(),
+                        progress.filteredUrls(),
+                        progress.startedAt()
+                )
+        );
+    }
+
+    /**
+     * Record that a page failed to crawl.
+     *
+     * @param sourceId the source being crawled
+     * @param url      the URL that failed
+     */
+    public void recordError(UUID sourceId, String url) {
+        activeCrawls.computeIfPresent(sourceId, (id, progress) -> {
+            List<String> updatedErrors = new ArrayList<>(progress.errorUrls());
+            updatedErrors.add(url);
+            return new CrawlProgress(
+                    progress.sourceId(),
+                    progress.status(),
+                    progress.pagesCrawled(),
+                    progress.pagesSkipped(),
+                    progress.pagesTotal(),
+                    progress.errors() + 1,
+                    updatedErrors,
+                    progress.filteredUrls(),
+                    progress.startedAt()
+            );
+        });
+    }
+
+    /**
+     * Record that a URL was excluded by scope filtering.
+     *
+     * @param sourceId the source being crawled
+     * @param url      the filtered URL
+     */
+    public void recordFiltered(UUID sourceId, String url) {
+        activeCrawls.computeIfPresent(sourceId, (id, progress) -> {
+            List<String> updatedFiltered = new ArrayList<>(progress.filteredUrls());
+            updatedFiltered.add(url);
+            return new CrawlProgress(
+                    progress.sourceId(),
+                    progress.status(),
+                    progress.pagesCrawled(),
+                    progress.pagesSkipped(),
+                    progress.pagesTotal(),
+                    progress.errors(),
+                    progress.errorUrls(),
+                    updatedFiltered,
+                    progress.startedAt()
+            );
+        });
+    }
+
+    /**
+     * Update the total discovered page count (may grow during BFS discovery).
+     *
+     * @param sourceId the source being crawled
+     * @param total    new total count
+     */
+    public void updateTotal(UUID sourceId, int total) {
+        activeCrawls.computeIfPresent(sourceId, (id, progress) ->
+                new CrawlProgress(
+                        progress.sourceId(),
+                        progress.status(),
+                        progress.pagesCrawled(),
+                        progress.pagesSkipped(),
+                        total,
+                        progress.errors(),
+                        progress.errorUrls(),
+                        progress.filteredUrls(),
+                        progress.startedAt()
+                )
+        );
+    }
+
+    /**
+     * Mark a crawl as completed.
+     *
+     * @param sourceId the source that finished crawling
+     */
+    public void completeCrawl(UUID sourceId) {
+        activeCrawls.computeIfPresent(sourceId, (id, progress) ->
+                new CrawlProgress(
+                        progress.sourceId(),
+                        CrawlProgress.Status.COMPLETED,
+                        progress.pagesCrawled(),
+                        progress.pagesSkipped(),
+                        progress.pagesTotal(),
+                        progress.errors(),
+                        progress.errorUrls(),
+                        progress.filteredUrls(),
+                        progress.startedAt()
+                )
+        );
+    }
+
+    /**
+     * Mark a crawl as failed.
+     *
+     * @param sourceId the source whose crawl failed
+     */
+    public void failCrawl(UUID sourceId) {
+        activeCrawls.computeIfPresent(sourceId, (id, progress) ->
+                new CrawlProgress(
+                        progress.sourceId(),
+                        CrawlProgress.Status.FAILED,
+                        progress.pagesCrawled(),
+                        progress.pagesSkipped(),
+                        progress.pagesTotal(),
+                        progress.errors(),
+                        progress.errorUrls(),
+                        progress.filteredUrls(),
+                        progress.startedAt()
+                )
+        );
+    }
+
+    /**
+     * Get the current progress snapshot for a crawl.
+     *
+     * @param sourceId the source to check
+     * @return progress snapshot, or empty if not tracking this source
+     */
+    public Optional<CrawlProgress> getProgress(UUID sourceId) {
+        return Optional.ofNullable(activeCrawls.get(sourceId));
+    }
+
+    /**
+     * Remove a crawl from tracking (cleanup after completion).
+     *
+     * @param sourceId the source to stop tracking
+     */
+    public void removeCrawl(UUID sourceId) {
+        activeCrawls.remove(sourceId);
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/CrawlScope.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlScope.java
@@ -13,6 +13,11 @@ public record CrawlScope(
         int maxPages
 ) {
 
+    public CrawlScope {
+        allowPatterns = allowPatterns == null ? List.of() : List.copyOf(allowPatterns);
+        blockPatterns = blockPatterns == null ? List.of() : List.copyOf(blockPatterns);
+    }
+
     /**
      * Creates a default scope with no pattern restrictions.
      *

--- a/src/main/java/dev/alexandria/crawl/CrawlScope.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlScope.java
@@ -1,5 +1,7 @@
 package dev.alexandria.crawl;
 
+import dev.alexandria.source.Source;
+
 import java.util.List;
 
 /**
@@ -26,5 +28,20 @@ public record CrawlScope(
      */
     public static CrawlScope withDefaults(int maxPages) {
         return new CrawlScope(List.of(), List.of(), null, maxPages);
+    }
+
+    /**
+     * Builds a CrawlScope from a Source entity's scope configuration fields.
+     *
+     * @param source the source entity with scope configuration
+     * @return crawl scope reflecting the source's allow/block patterns, depth, and page limits
+     */
+    public static CrawlScope fromSource(Source source) {
+        return new CrawlScope(
+                source.getAllowPatternList(),
+                source.getBlockPatternList(),
+                source.getMaxDepth(),
+                source.getMaxPages() != null ? source.getMaxPages() : 500
+        );
     }
 }

--- a/src/main/java/dev/alexandria/crawl/CrawlScope.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlScope.java
@@ -1,0 +1,25 @@
+package dev.alexandria.crawl;
+
+import java.util.List;
+
+/**
+ * Immutable scope configuration for crawl URL filtering.
+ * Defines allow/block glob patterns, maximum crawl depth, and page limits.
+ */
+public record CrawlScope(
+        List<String> allowPatterns,
+        List<String> blockPatterns,
+        Integer maxDepth,
+        int maxPages
+) {
+
+    /**
+     * Creates a default scope with no pattern restrictions.
+     *
+     * @param maxPages maximum number of pages to crawl
+     * @return scope with empty allow/block patterns and unlimited depth
+     */
+    public static CrawlScope withDefaults(int maxPages) {
+        return new CrawlScope(List.of(), List.of(), null, maxPages);
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/CrawlService.java
+++ b/src/main/java/dev/alexandria/crawl/CrawlService.java
@@ -1,19 +1,26 @@
 package dev.alexandria.crawl;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
+import dev.alexandria.ingestion.IngestionService;
+import dev.alexandria.ingestion.IngestionState;
+import dev.alexandria.ingestion.IngestionStateRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
 /**
  * Crawl orchestrator that ties together page discovery and per-page crawling.
- * Tries sitemap.xml first for URL discovery. If no sitemap, falls back to
- * BFS link crawling starting from rootUrl.
+ * Supports scope filtering, depth tracking, incremental ingestion,
+ * llms-full.txt hybrid ingestion, progress tracking, and deleted page cleanup.
  */
 @Service
 public class CrawlService {
@@ -22,87 +29,269 @@ public class CrawlService {
 
     private final Crawl4AiClient crawl4AiClient;
     private final PageDiscoveryService pageDiscoveryService;
+    private final CrawlProgressTracker progressTracker;
+    private final IngestionService ingestionService;
+    private final IngestionStateRepository ingestionStateRepository;
 
     public CrawlService(Crawl4AiClient crawl4AiClient,
-                        PageDiscoveryService pageDiscoveryService) {
+                        PageDiscoveryService pageDiscoveryService,
+                        CrawlProgressTracker progressTracker,
+                        IngestionService ingestionService,
+                        IngestionStateRepository ingestionStateRepository) {
         this.crawl4AiClient = crawl4AiClient;
         this.pageDiscoveryService = pageDiscoveryService;
+        this.progressTracker = progressTracker;
+        this.ingestionService = ingestionService;
+        this.ingestionStateRepository = ingestionStateRepository;
     }
 
     /**
-     * Crawl a documentation site from a root URL.
-     * Tries sitemap.xml first for URL discovery. If no sitemap, falls back to
-     * BFS link crawling starting from rootUrl.
+     * Crawl a documentation site from a root URL with default scope.
+     * Delegates to the full scope-aware method.
      *
-     * @param rootUrl the starting URL for the crawl
+     * @param rootUrl  the starting URL for the crawl
      * @param maxPages maximum number of pages to crawl (safety limit)
      * @return list of crawl results for each successfully crawled page
      */
     public List<CrawlResult> crawlSite(String rootUrl, int maxPages) {
+        return crawlSite(null, rootUrl, CrawlScope.withDefaults(maxPages));
+    }
+
+    /**
+     * Crawl a documentation site with scope filtering, depth tracking, and progress reporting.
+     * Tries sitemap.xml / llms.txt first for URL discovery. If no discovery source,
+     * falls back to BFS link crawling starting from rootUrl.
+     *
+     * @param sourceId the UUID of the source being crawled (null for legacy callers)
+     * @param rootUrl  the starting URL for the crawl
+     * @param scope    crawl scope with allow/block patterns, max depth, and page limits
+     * @return list of crawl results for each successfully crawled page
+     */
+    public List<CrawlResult> crawlSite(UUID sourceId, String rootUrl, CrawlScope scope) {
         PageDiscoveryService.DiscoveryResult discovery = pageDiscoveryService.discoverUrls(rootUrl);
         boolean followLinks = discovery.method() == PageDiscoveryService.DiscoveryMethod.LINK_CRAWL;
 
-        LinkedHashSet<String> queue = seedQueue(rootUrl, discovery);
+        // Handle llms-full.txt hybrid ingestion
+        Set<String> llmsFullCoveredUrls = new HashSet<>();
+        if (discovery.llmsFullContent() != null && sourceId != null) {
+            log.info("Ingesting llms-full.txt content directly for {}", rootUrl);
+            ingestionService.ingestPage(discovery.llmsFullContent(), rootUrl, Instant.now().toString());
+            // All URLs from LLMS_FULL_TXT discovery are covered by the full content
+            if (discovery.method() == PageDiscoveryService.DiscoveryMethod.LLMS_FULL_TXT) {
+                llmsFullCoveredUrls.addAll(discovery.urls().stream()
+                        .map(UrlNormalizer::normalize)
+                        .toList());
+            }
+        }
+
+        // Seed queue with depth tracking: URL -> depth
+        LinkedHashMap<String, Integer> queue = seedQueue(rootUrl, discovery, scope);
         Set<String> visited = new HashSet<>();
         List<CrawlResult> results = new ArrayList<>();
+        Set<String> crawledUrls = new HashSet<>();
 
-        log.info("Starting crawl of {} (discovery method: {}, seed URLs: {})",
-                rootUrl, discovery.method(), queue.size());
+        log.info("Starting crawl of {} (discovery method: {}, seed URLs: {}, scope: maxDepth={}, maxPages={})",
+                rootUrl, discovery.method(), queue.size(), scope.maxDepth(), scope.maxPages());
 
-        while (!queue.isEmpty() && results.size() < maxPages) {
-            String normalized = dequeueAndNormalize(queue);
-            if (!visited.add(normalized)) {
-                continue;
+        if (sourceId != null) {
+            progressTracker.startCrawl(sourceId, queue.size());
+        }
+
+        try {
+            while (!queue.isEmpty() && results.size() < scope.maxPages()) {
+                Map.Entry<String, Integer> entry = dequeueFirst(queue);
+                String normalized = UrlNormalizer.normalize(entry.getKey());
+                int depth = entry.getValue();
+
+                if (!visited.add(normalized)) {
+                    continue;
+                }
+
+                // Check max depth
+                if (scope.maxDepth() != null && depth > scope.maxDepth()) {
+                    continue;
+                }
+
+                // Skip URLs covered by llms-full.txt
+                if (llmsFullCoveredUrls.contains(normalized)) {
+                    log.debug("Skipping {} (covered by llms-full.txt)", normalized);
+                    if (sourceId != null) {
+                        progressTracker.recordPageSkipped(sourceId);
+                    }
+                    crawledUrls.add(normalized);
+                    continue;
+                }
+
+                log.info("Crawling [{}/{}]: {}", results.size() + 1, scope.maxPages(), normalized);
+                processPage(sourceId, normalized, rootUrl, depth, followLinks, scope, results,
+                        queue, visited, crawledUrls);
             }
-            log.info("Crawling [{}/{}]: {}", results.size() + 1, maxPages, normalized);
-            processPage(normalized, rootUrl, followLinks, results, queue, visited);
+
+            // Post-crawl cleanup: remove orphaned pages
+            if (sourceId != null) {
+                cleanupDeletedPages(sourceId, crawledUrls);
+                progressTracker.completeCrawl(sourceId);
+            }
+        } catch (Exception e) {
+            if (sourceId != null) {
+                progressTracker.failCrawl(sourceId);
+            }
+            throw e;
         }
 
         log.info("Crawl complete: {} pages crawled from {}", results.size(), rootUrl);
         return results;
     }
 
-    private LinkedHashSet<String> seedQueue(String rootUrl,
-                                            PageDiscoveryService.DiscoveryResult discovery) {
-        LinkedHashSet<String> queue = new LinkedHashSet<>();
+    private LinkedHashMap<String, Integer> seedQueue(String rootUrl,
+                                                      PageDiscoveryService.DiscoveryResult discovery,
+                                                      CrawlScope scope) {
+        LinkedHashMap<String, Integer> queue = new LinkedHashMap<>();
         if (!discovery.urls().isEmpty()) {
-            queue.addAll(discovery.urls());
-        } else {
-            queue.add(UrlNormalizer.normalize(rootUrl));
+            for (String url : discovery.urls()) {
+                String normalized = UrlNormalizer.normalize(url);
+                if (UrlScopeFilter.isAllowed(normalized, rootUrl, scope)) {
+                    queue.put(normalized, 0);
+                }
+            }
+        }
+        if (queue.isEmpty()) {
+            queue.put(UrlNormalizer.normalize(rootUrl), 0);
         }
         return queue;
     }
 
-    private String dequeueAndNormalize(LinkedHashSet<String> queue) {
-        String url = queue.iterator().next();
-        queue.remove(url);
-        return UrlNormalizer.normalize(url);
+    private Map.Entry<String, Integer> dequeueFirst(LinkedHashMap<String, Integer> queue) {
+        var iterator = queue.entrySet().iterator();
+        var entry = iterator.next();
+        iterator.remove();
+        return entry;
     }
 
-    private void processPage(String url, String rootUrl, boolean followLinks,
-                             List<CrawlResult> results, LinkedHashSet<String> queue,
-                             Set<String> visited) {
+    private void processPage(UUID sourceId, String url, String rootUrl, int depth,
+                             boolean followLinks, CrawlScope scope,
+                             List<CrawlResult> results, LinkedHashMap<String, Integer> queue,
+                             Set<String> visited, Set<String> crawledUrls) {
         try {
             CrawlResult result = crawl4AiClient.crawl(url);
             if (result.success()) {
                 results.add(result);
+                crawledUrls.add(url);
+
+                // Incremental ingestion with hash-based change detection
+                if (sourceId != null) {
+                    IngestionService.IngestResult ingestResult = ingestIncremental(sourceId, url, result.markdown());
+                    if (ingestResult.skipped()) {
+                        progressTracker.recordPageSkipped(sourceId);
+                    } else {
+                        progressTracker.recordPageCrawled(sourceId);
+                    }
+                }
+
                 if (followLinks) {
-                    enqueueDiscoveredLinks(result, rootUrl, queue, visited);
+                    enqueueDiscoveredLinks(sourceId, result, rootUrl, depth, scope, queue, visited);
                 }
             } else {
                 log.warn("Failed to crawl {}: {}", url, result.errorMessage());
+                if (sourceId != null) {
+                    progressTracker.recordError(sourceId, url);
+                }
             }
         } catch (Exception e) {
             log.error("Error crawling {}: {}", url, e.getMessage());
+            if (sourceId != null) {
+                progressTracker.recordError(sourceId, url);
+            }
         }
     }
 
-    private void enqueueDiscoveredLinks(CrawlResult result, String rootUrl,
-                                        LinkedHashSet<String> queue, Set<String> visited) {
-        result.internalLinks().stream()
-                .map(UrlNormalizer::normalize)
-                .filter(link -> UrlNormalizer.isSameSite(rootUrl, link))
-                .filter(link -> !visited.contains(link))
-                .forEach(queue::add);
+    /**
+     * Perform incremental ingestion for a single page: compare content hash,
+     * skip if unchanged, delete old chunks and re-ingest if changed or new.
+     */
+    private IngestionService.IngestResult ingestIncremental(UUID sourceId, String normalizedUrl, String markdown) {
+        String newHash = ContentHasher.sha256(markdown);
+
+        Optional<IngestionState> existingState =
+                ingestionStateRepository.findBySourceIdAndPageUrl(sourceId, normalizedUrl);
+
+        if (existingState.isPresent() && existingState.get().getContentHash().equals(newHash)) {
+            log.debug("Content unchanged for {}, skipping ingestion", normalizedUrl);
+            return new IngestionService.IngestResult(0, true, false);
+        }
+
+        // Delete old chunks before re-ingesting
+        ingestionService.deleteChunksForUrl(normalizedUrl);
+
+        // Chunk and embed
+        int chunkCount = ingestionService.ingestPage(markdown, normalizedUrl, Instant.now().toString());
+
+        // Update or create ingestion state
+        if (existingState.isPresent()) {
+            IngestionState state = existingState.get();
+            state.setContentHash(newHash);
+            state.setLastIngestedAt(Instant.now());
+            ingestionStateRepository.save(state);
+        } else {
+            ingestionStateRepository.save(new IngestionState(sourceId, normalizedUrl, newHash));
+        }
+
+        log.debug("Ingested {} chunks for {} ({})", chunkCount, normalizedUrl,
+                existingState.isPresent() ? "updated" : "new");
+        return new IngestionService.IngestResult(chunkCount, false, true);
+    }
+
+    private void enqueueDiscoveredLinks(UUID sourceId, CrawlResult result, String rootUrl,
+                                        int parentDepth, CrawlScope scope,
+                                        LinkedHashMap<String, Integer> queue,
+                                        Set<String> visited) {
+        int newUrlCount = 0;
+        for (String link : result.internalLinks()) {
+            String normalized = UrlNormalizer.normalize(link);
+            if (!UrlNormalizer.isSameSite(rootUrl, normalized)) {
+                continue;
+            }
+            if (visited.contains(normalized) || queue.containsKey(normalized)) {
+                continue;
+            }
+            if (!UrlScopeFilter.isAllowed(normalized, rootUrl, scope)) {
+                log.debug("Filtered URL by scope: {}", normalized);
+                if (sourceId != null) {
+                    progressTracker.recordFiltered(sourceId, normalized);
+                }
+                continue;
+            }
+            queue.put(normalized, parentDepth + 1);
+            newUrlCount++;
+        }
+        if (newUrlCount > 0 && sourceId != null) {
+            progressTracker.updateTotal(sourceId, queue.size() + visited.size());
+        }
+    }
+
+    /**
+     * Remove chunks and ingestion state for pages that no longer exist in the crawled site.
+     * Only runs when there are pre-existing ingestion states (incremental recrawl).
+     */
+    private void cleanupDeletedPages(UUID sourceId, Set<String> crawledUrls) {
+        List<IngestionState> allStates = ingestionStateRepository.findAllBySourceId(sourceId);
+        if (allStates.isEmpty()) {
+            return;
+        }
+
+        List<String> orphanedUrls = allStates.stream()
+                .map(IngestionState::getPageUrl)
+                .filter(pageUrl -> !crawledUrls.contains(pageUrl))
+                .toList();
+
+        if (orphanedUrls.isEmpty()) {
+            return;
+        }
+
+        log.info("Cleaning up {} deleted pages for source {}", orphanedUrls.size(), sourceId);
+        for (String orphanUrl : orphanedUrls) {
+            ingestionService.deleteChunksForUrl(orphanUrl);
+        }
+        ingestionStateRepository.deleteAllBySourceIdAndPageUrlNotIn(sourceId, crawledUrls);
     }
 }

--- a/src/main/java/dev/alexandria/crawl/LlmsTxtParser.java
+++ b/src/main/java/dev/alexandria/crawl/LlmsTxtParser.java
@@ -1,0 +1,159 @@
+package dev.alexandria.crawl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses llms.txt and llms-full.txt files to extract URLs and content.
+ *
+ * <p>The llms.txt format is a machine-readable Markdown file listing documentation pages:
+ * <pre>
+ * # Project Name
+ *
+ * > Optional summary
+ *
+ * ## Section
+ *
+ * - [Page Title](https://url): Optional description
+ * </pre>
+ *
+ * <p>llms-full.txt is a concatenated Markdown document containing the actual documentation
+ * content, intended for direct ingestion rather than as a link index.
+ *
+ * @see <a href="https://llmstxt.org/">llms.txt specification</a>
+ */
+public final class LlmsTxtParser {
+
+    private static final Pattern MARKDOWN_LINK_PATTERN =
+            Pattern.compile("\\[([^\\]]+)\\]\\(([^)]+)\\)");
+
+    /**
+     * Minimum ratio of lines containing markdown links to total non-blank, non-header lines
+     * for content to be classified as a link index (llms.txt) rather than full content.
+     */
+    private static final double LINK_INDEX_THRESHOLD = 0.3;
+
+    private LlmsTxtParser() {
+        // utility class
+    }
+
+    /**
+     * Extract URLs from llms.txt-format content.
+     *
+     * <p>Parses line-by-line, extracting URLs from Markdown link syntax:
+     * {@code - [Title](URL)} or {@code [Title](URL)} (with or without leading dash).
+     * Ignores header lines (starting with {@code #}), blank lines, and blockquote lines
+     * (starting with {@code >}).
+     *
+     * @param llmsTxtContent the raw content of an llms.txt file
+     * @return list of extracted URL strings, or empty list if content is null/blank
+     */
+    public static List<String> parseUrls(String llmsTxtContent) {
+        if (llmsTxtContent == null || llmsTxtContent.isBlank()) {
+            return List.of();
+        }
+
+        List<String> urls = new ArrayList<>();
+        for (String line : llmsTxtContent.lines().toList()) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#") || trimmed.startsWith(">")) {
+                continue;
+            }
+            Matcher matcher = MARKDOWN_LINK_PATTERN.matcher(trimmed);
+            if (matcher.find()) {
+                urls.add(matcher.group(2));
+            }
+        }
+        return Collections.unmodifiableList(urls);
+    }
+
+    /**
+     * Quick heuristic to determine if content is an llms.txt link index.
+     *
+     * <p>Returns {@code true} if the content starts with a {@code #} header and
+     * contains a significant proportion of markdown links relative to content lines.
+     * This distinguishes llms.txt (a link index) from llms-full.txt (raw Markdown content).
+     *
+     * @param content the content to check
+     * @return true if content appears to be an llms.txt link index
+     */
+    public static boolean isLlmsTxtContent(String content) {
+        if (content == null || content.isBlank()) {
+            return false;
+        }
+
+        boolean startsWithHeader = false;
+        int contentLines = 0;
+        int linkLines = 0;
+
+        for (String line : content.lines().toList()) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (!startsWithHeader) {
+                startsWithHeader = trimmed.startsWith("#");
+                if (!startsWithHeader) {
+                    return false;
+                }
+                continue;
+            }
+            if (trimmed.startsWith("#") || trimmed.startsWith(">")) {
+                continue;
+            }
+            contentLines++;
+            if (MARKDOWN_LINK_PATTERN.matcher(trimmed).find()) {
+                linkLines++;
+            }
+        }
+
+        if (contentLines == 0) {
+            return false;
+        }
+
+        return (double) linkLines / contentLines >= LINK_INDEX_THRESHOLD;
+    }
+
+    /**
+     * Parse content and classify it as llms.txt (link index) or llms-full.txt (raw content).
+     *
+     * <p>If the content looks like a link index: extracts URLs, rawContent is empty.
+     * If the content looks like full documentation: extracts any inline URLs,
+     * rawContent contains the full content for direct ingestion.
+     *
+     * @param content the raw content of an llms.txt or llms-full.txt file
+     * @return parsed result with URLs, raw content, and content type flag
+     */
+    public static LlmsTxtResult parse(String content) {
+        if (content == null || content.isBlank()) {
+            return new LlmsTxtResult(List.of(), "", false);
+        }
+
+        List<String> urls = parseUrls(content);
+        boolean isIndex = isLlmsTxtContent(content);
+
+        if (isIndex) {
+            return new LlmsTxtResult(urls, "", false);
+        } else {
+            return new LlmsTxtResult(urls, content, true);
+        }
+    }
+
+    /**
+     * Result of parsing llms.txt or llms-full.txt content.
+     *
+     * @param urls extracted URLs from markdown links
+     * @param rawContent the original content (non-empty only for llms-full.txt)
+     * @param isFullContent true when content is llms-full.txt (large Markdown for direct ingestion)
+     */
+    public record LlmsTxtResult(List<String> urls, String rawContent, boolean isFullContent) {
+
+        public LlmsTxtResult {
+            urls = urls == null ? List.of() : List.copyOf(urls);
+            rawContent = rawContent == null ? "" : rawContent;
+        }
+    }
+}

--- a/src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
+++ b/src/main/java/dev/alexandria/crawl/PageDiscoveryService.java
@@ -1,30 +1,58 @@
 package dev.alexandria.crawl;
 
+import java.net.URI;
+import java.net.URL;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
 
 /**
- * Coordinates URL discovery for a site. Tries sitemap.xml first via SitemapParser,
- * falls back to signaling the caller to use recursive link crawling.
+ * Coordinates URL discovery for a site using a priority cascade:
+ * <ol>
+ *   <li>llms.txt / llms-full.txt (machine-readable documentation index)</li>
+ *   <li>sitemap.xml (via {@link SitemapParser})</li>
+ *   <li>BFS link crawling (caller seeds with root URL)</li>
+ * </ol>
  */
 @Service
 public class PageDiscoveryService {
 
-    private final SitemapParser sitemapParser;
+    private static final Logger log = LoggerFactory.getLogger(PageDiscoveryService.class);
 
-    public PageDiscoveryService(SitemapParser sitemapParser) {
+    private final SitemapParser sitemapParser;
+    private final RestClient restClient;
+
+    public PageDiscoveryService(SitemapParser sitemapParser, RestClient.Builder restClientBuilder) {
         this.sitemapParser = sitemapParser;
+        this.restClient = restClientBuilder.build();
     }
 
     /**
-     * Discover URLs for a site. Tries sitemap.xml first, falls back to empty
-     * (caller will use recursive link crawling).
+     * Discover URLs for a site using the priority cascade:
+     * llms.txt/llms-full.txt first, then sitemap.xml, then link crawl fallback.
      *
      * @param rootUrl the root URL of the site to discover
-     * @return discovered URLs, or empty list (caller should seed with rootUrl for link crawling)
+     * @return discovered URLs with discovery method and optional full content
      */
     public DiscoveryResult discoverUrls(String rootUrl) {
+        String baseUrl = normalizeToBase(rootUrl);
+
+        // 1. Try llms-full.txt first (provides content for direct ingestion)
+        DiscoveryResult llmsFullResult = tryLlmsFullTxt(baseUrl);
+        if (llmsFullResult != null) {
+            return llmsFullResult;
+        }
+
+        // 2. Try llms.txt (link index)
+        DiscoveryResult llmsTxtResult = tryLlmsTxt(baseUrl);
+        if (llmsTxtResult != null) {
+            return llmsTxtResult;
+        }
+
+        // 3. Try sitemap.xml
         List<String> sitemapUrls = sitemapParser.discoverFromSitemap(rootUrl);
         if (!sitemapUrls.isEmpty()) {
             List<String> filtered = sitemapUrls.stream()
@@ -32,14 +60,110 @@ public class PageDiscoveryService {
                     .map(UrlNormalizer::normalize)
                     .distinct()
                     .toList();
-            return new DiscoveryResult(filtered, DiscoveryMethod.SITEMAP);
+            return new DiscoveryResult(filtered, DiscoveryMethod.SITEMAP, null);
         }
-        return new DiscoveryResult(List.of(), DiscoveryMethod.LINK_CRAWL);
+
+        // 4. Fall back to link crawl
+        return new DiscoveryResult(List.of(), DiscoveryMethod.LINK_CRAWL, null);
     }
 
-    public enum DiscoveryMethod { SITEMAP, LINK_CRAWL }
+    private DiscoveryResult tryLlmsFullTxt(String baseUrl) {
+        String llmsFullUrl = baseUrl + "/llms-full.txt";
+        String content = fetchText(llmsFullUrl);
+        if (content == null) {
+            return null;
+        }
 
-    public record DiscoveryResult(List<String> urls, DiscoveryMethod method) {
+        LlmsTxtParser.LlmsTxtResult parsed = LlmsTxtParser.parse(content);
+        if (parsed.isFullContent()) {
+            log.info("Discovered llms-full.txt at {} ({} inline URLs)", llmsFullUrl, parsed.urls().size());
+            return new DiscoveryResult(parsed.urls(), DiscoveryMethod.LLMS_FULL_TXT, parsed.rawContent());
+        }
+
+        // Content at llms-full.txt path but looks like a link index -- treat as llms.txt
+        if (!parsed.urls().isEmpty()) {
+            log.info("llms-full.txt at {} is a link index ({} URLs)", llmsFullUrl, parsed.urls().size());
+            return new DiscoveryResult(parsed.urls(), DiscoveryMethod.LLMS_TXT, null);
+        }
+
+        return null;
+    }
+
+    private DiscoveryResult tryLlmsTxt(String baseUrl) {
+        String llmsTxtUrl = baseUrl + "/llms.txt";
+        String content = fetchText(llmsTxtUrl);
+        if (content == null) {
+            return null;
+        }
+
+        List<String> urls = LlmsTxtParser.parseUrls(content);
+        if (!urls.isEmpty()) {
+            log.info("Discovered llms.txt at {} ({} URLs)", llmsTxtUrl, urls.size());
+            return new DiscoveryResult(urls, DiscoveryMethod.LLMS_TXT, null);
+        }
+
+        return null;
+    }
+
+    /**
+     * Fetch text content from a URL, returning null on any error (404, connection error, etc.).
+     */
+    private String fetchText(String url) {
+        try {
+            return restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(String.class);
+        } catch (Exception e) {
+            log.debug("Could not fetch {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Extract scheme + host (+ port if non-default) from a URL.
+     */
+    private String normalizeToBase(String rootUrl) {
+        try {
+            URI uri = URI.create(rootUrl);
+            URL url = uri.toURL();
+            String protocol = url.getProtocol();
+            String host = url.getHost();
+            int port = url.getPort();
+
+            if (port == -1 || (protocol.equals("http") && port == 80)
+                    || (protocol.equals("https") && port == 443)) {
+                return protocol + "://" + host;
+            }
+            return protocol + "://" + host + ":" + port;
+        } catch (Exception e) {
+            log.warn("Could not parse base URL from {}: {}", rootUrl, e.getMessage());
+            return rootUrl;
+        }
+    }
+
+    /**
+     * Method used for URL discovery.
+     */
+    public enum DiscoveryMethod {
+        /** URLs discovered from llms.txt link index */
+        LLMS_TXT,
+        /** Full content discovered from llms-full.txt */
+        LLMS_FULL_TXT,
+        /** URLs discovered from sitemap.xml */
+        SITEMAP,
+        /** No discovery source found; caller should use BFS link crawling */
+        LINK_CRAWL
+    }
+
+    /**
+     * Result of URL discovery for a site.
+     *
+     * @param urls            discovered URLs to crawl
+     * @param method          how URLs were discovered
+     * @param llmsFullContent raw llms-full.txt content for direct ingestion (null unless method is LLMS_FULL_TXT)
+     */
+    public record DiscoveryResult(List<String> urls, DiscoveryMethod method, String llmsFullContent) {
         public DiscoveryResult {
             urls = urls == null ? List.of() : List.copyOf(urls);
         }

--- a/src/main/java/dev/alexandria/crawl/UrlScopeFilter.java
+++ b/src/main/java/dev/alexandria/crawl/UrlScopeFilter.java
@@ -1,5 +1,10 @@
 package dev.alexandria.crawl;
 
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+
 /**
  * Static utility for filtering URLs against a {@link CrawlScope}.
  * Block patterns take priority over allow patterns; external URLs are always rejected.
@@ -12,6 +17,14 @@ public final class UrlScopeFilter {
 
     /**
      * Check whether a URL is allowed by the given scope relative to the root URL.
+     * <p>
+     * Filtering order:
+     * <ol>
+     *   <li>Reject if URL is malformed or not on the same site as rootUrl</li>
+     *   <li>Reject if URL path matches any block pattern (block takes priority)</li>
+     *   <li>If allow patterns exist, accept only if URL path matches at least one</li>
+     *   <li>If no allow patterns, accept all same-site URLs</li>
+     * </ol>
      *
      * @param url the candidate URL to check
      * @param rootUrl the root URL defining the site boundary
@@ -19,6 +32,40 @@ public final class UrlScopeFilter {
      * @return true if the URL passes scope filtering
      */
     public static boolean isAllowed(String url, String rootUrl, CrawlScope scope) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        String urlPath;
+        try {
+            urlPath = URI.create(url).getPath();
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+
+        if (!UrlNormalizer.isSameSite(rootUrl, url)) {
+            return false;
+        }
+
+        if (urlPath == null || urlPath.isEmpty()) {
+            urlPath = "/";
+        }
+
+        Path path = Path.of(urlPath);
+
+        for (String blockPattern : scope.blockPatterns()) {
+            PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + blockPattern);
+            if (matcher.matches(path)) {
+                return false;
+            }
+        }
+
+        if (!scope.allowPatterns().isEmpty()) {
+            for (String allowPattern : scope.allowPatterns()) {
+                PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + allowPattern);
+                if (matcher.matches(path)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/dev/alexandria/crawl/UrlScopeFilter.java
+++ b/src/main/java/dev/alexandria/crawl/UrlScopeFilter.java
@@ -1,0 +1,24 @@
+package dev.alexandria.crawl;
+
+/**
+ * Static utility for filtering URLs against a {@link CrawlScope}.
+ * Block patterns take priority over allow patterns; external URLs are always rejected.
+ */
+public final class UrlScopeFilter {
+
+    private UrlScopeFilter() {
+        // utility class
+    }
+
+    /**
+     * Check whether a URL is allowed by the given scope relative to the root URL.
+     *
+     * @param url the candidate URL to check
+     * @param rootUrl the root URL defining the site boundary
+     * @param scope the crawl scope with allow/block patterns
+     * @return true if the URL passes scope filtering
+     */
+    public static boolean isAllowed(String url, String rootUrl, CrawlScope scope) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java
+++ b/src/main/java/dev/alexandria/ingestion/IngestionStateRepository.java
@@ -2,13 +2,34 @@ package dev.alexandria.ingestion;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 /**
  * Spring Data repository for {@link IngestionState} entities.
+ *
+ * <p>Provides query methods for incremental crawling: lookup by source and page URL,
+ * bulk retrieval by source, and orphaned page cleanup.
  */
 public interface IngestionStateRepository extends JpaRepository<IngestionState, UUID> {
 
     Optional<IngestionState> findBySourceIdAndPageUrl(UUID sourceId, String pageUrl);
+
+    /**
+     * Find all ingestion states for a given source, used for deleted page detection.
+     */
+    List<IngestionState> findAllBySourceId(UUID sourceId);
+
+    /**
+     * Delete all ingestion states for a source (full recrawl reset).
+     */
+    void deleteAllBySourceId(UUID sourceId);
+
+    /**
+     * Delete orphaned ingestion states: pages that were previously indexed but are no longer
+     * present in the current crawl results.
+     */
+    void deleteAllBySourceIdAndPageUrlNotIn(UUID sourceId, Collection<String> pageUrls);
 }

--- a/src/main/java/dev/alexandria/mcp/McpToolService.java
+++ b/src/main/java/dev/alexandria/mcp/McpToolService.java
@@ -1,14 +1,25 @@
 package dev.alexandria.mcp;
 
+import dev.alexandria.crawl.CrawlProgress;
+import dev.alexandria.crawl.CrawlProgressTracker;
+import dev.alexandria.crawl.CrawlResult;
+import dev.alexandria.crawl.CrawlScope;
+import dev.alexandria.crawl.CrawlService;
+import dev.alexandria.ingestion.IngestionService;
 import dev.alexandria.search.SearchRequest;
 import dev.alexandria.search.SearchResult;
 import dev.alexandria.search.SearchService;
 import dev.alexandria.source.Source;
 import dev.alexandria.source.SourceRepository;
+import dev.alexandria.source.SourceStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,9 +32,8 @@ import java.util.UUID;
  * Tool methods follow the structured error pattern: all exceptions are caught and
  * returned as descriptive error strings, never thrown.
  *
- * <p>Currently functional tools: {@code search_docs}, {@code list_sources}.
- * Stub tools for Phase 6: {@code add_source}, {@code remove_source},
- * {@code crawl_status}, {@code recrawl_source}.
+ * <p>Functional tools: {@code search_docs}, {@code list_sources}, {@code add_source},
+ * {@code remove_source}, {@code crawl_status}, {@code recrawl_source}.
  *
  * @see TokenBudgetTruncator
  * @see McpToolConfig
@@ -31,16 +41,27 @@ import java.util.UUID;
 @Service
 public class McpToolService {
 
+    private static final Logger log = LoggerFactory.getLogger(McpToolService.class);
+
     private final SearchService searchService;
     private final SourceRepository sourceRepository;
     private final TokenBudgetTruncator truncator;
+    private final CrawlService crawlService;
+    private final CrawlProgressTracker progressTracker;
+    private final IngestionService ingestionService;
 
     public McpToolService(SearchService searchService,
                           SourceRepository sourceRepository,
-                          TokenBudgetTruncator truncator) {
+                          TokenBudgetTruncator truncator,
+                          CrawlService crawlService,
+                          CrawlProgressTracker progressTracker,
+                          IngestionService ingestionService) {
         this.searchService = searchService;
         this.sourceRepository = sourceRepository;
         this.truncator = truncator;
+        this.crawlService = crawlService;
+        this.progressTracker = progressTracker;
+        this.ingestionService = ingestionService;
     }
 
     /**
@@ -97,28 +118,47 @@ public class McpToolService {
     }
 
     /**
-     * Adds a new documentation source URL for indexing (stub for Phase 6 orchestration).
+     * Adds a new documentation source URL for indexing with optional scope controls.
+     * Creates the source, saves it, and triggers an async crawl via virtual thread.
      */
     @Tool(name = "add_source",
-          description = "Add a new documentation source URL for indexing. The source is created in PENDING status.")
+          description = "Add a documentation source URL for crawling and indexing. "
+                      + "Optionally specify scope controls: allow/block URL patterns (glob), max depth, max pages.")
     public String addSource(
             @ToolParam(description = "URL of the documentation site to index") String url,
-            @ToolParam(description = "Human-readable name for this source") String name) {
+            @ToolParam(description = "Human-readable name for this source") String name,
+            @ToolParam(description = "Comma-separated glob patterns for allowed URL paths (e.g., '/docs/**,/api/**'). Empty = allow all.", required = false) String allowPatterns,
+            @ToolParam(description = "Comma-separated glob patterns for blocked URL paths (e.g., '/archive/**,/old/**'). Empty = block none.", required = false) String blockPatterns,
+            @ToolParam(description = "Maximum crawl depth from root URL. Null = unlimited.", required = false) Integer maxDepth,
+            @ToolParam(description = "Maximum number of pages to crawl (default: 500).", required = false) Integer maxPages,
+            @ToolParam(description = "Manual llms.txt URL if auto-detection fails.", required = false) String llmsTxtUrl) {
         try {
             if (url == null || url.isBlank()) {
                 return "Error: URL must not be empty. Provide a documentation site URL.";
             }
             Source source = new Source(url, name);
+            source.setAllowPatterns(allowPatterns);
+            source.setBlockPatterns(blockPatterns);
+            source.setMaxDepth(maxDepth);
+            source.setMaxPages(maxPages != null ? maxPages : 500);
+            source.setLlmsTxtUrl(llmsTxtUrl);
+            source.setStatus(SourceStatus.CRAWLING);
             sourceRepository.save(source);
-            return "Source '%s' added in PENDING status. Crawling will be available in a future update."
-                    .formatted(name);
+
+            UUID sourceId = source.getId();
+            CrawlScope scope = CrawlScope.fromSource(source);
+
+            dispatchCrawl(sourceId, url, scope, false);
+
+            return "Source '%s' created (ID: %s). Crawl started. Check progress with crawl_status."
+                    .formatted(name, source.getId());
         } catch (Exception e) {
             return "Error adding source: " + e.getMessage();
         }
     }
 
     /**
-     * Removes a documentation source and its indexed data by ID (stub for Phase 6 cascade).
+     * Removes a documentation source and its indexed data by ID.
      */
     @Tool(name = "remove_source",
           description = "Remove a documentation source and its indexed data by source ID.")
@@ -136,7 +176,7 @@ public class McpToolService {
     }
 
     /**
-     * Checks crawl status and index statistics for a source (stub for Phase 6 progress tracking).
+     * Checks crawl status: real-time progress for active crawls, summary for completed sources.
      */
     @Tool(name = "crawl_status",
           description = "Check the crawl status and index statistics for a documentation source by ID.")
@@ -149,13 +189,13 @@ public class McpToolService {
                 return "Error: Source %s not found.".formatted(sourceId);
             }
             Source source = found.get();
-            return ("Source: %s | Status: %s | Chunks: %d | Last crawled: %s. "
-                    + "Detailed crawl progress will be available in a future update.")
-                    .formatted(
-                            source.getName(),
-                            source.getStatus(),
-                            source.getChunkCount(),
-                            source.getLastCrawledAt() != null ? source.getLastCrawledAt().toString() : "never");
+
+            Optional<CrawlProgress> progress = progressTracker.getProgress(uuid);
+            if (progress.isPresent()) {
+                return formatActiveProgress(source, progress.get());
+            }
+
+            return formatCompletedSummary(source);
         } catch (IllegalArgumentException e) {
             return "Error: Invalid source ID format. Provide a valid UUID.";
         } catch (Exception e) {
@@ -164,12 +204,20 @@ public class McpToolService {
     }
 
     /**
-     * Requests a re-crawl of an existing source (stub for Phase 6 crawl orchestration).
+     * Triggers a recrawl of an existing documentation source.
+     * Incremental by default (only re-processes changed pages). Use full=true for complete re-processing.
+     * Scope overrides are one-time and do not persist to the Source entity.
      */
     @Tool(name = "recrawl_source",
-          description = "Request a re-crawl of an existing documentation source to refresh its indexed content.")
+          description = "Trigger a recrawl of an existing documentation source. "
+                      + "Incremental by default (only re-processes changed pages). Use full=true to force complete re-processing.")
     public String recrawlSource(
-            @ToolParam(description = "UUID of the source to re-crawl") String sourceId) {
+            @ToolParam(description = "UUID of the source to re-crawl") String sourceId,
+            @ToolParam(description = "Force full recrawl (re-process all pages, not just changed ones)", required = false) Boolean full,
+            @ToolParam(description = "Override allow patterns for this crawl run (comma-separated globs)", required = false) String allowPatterns,
+            @ToolParam(description = "Override block patterns for this crawl run (comma-separated globs)", required = false) String blockPatterns,
+            @ToolParam(description = "Override max depth for this crawl run", required = false) Integer maxDepth,
+            @ToolParam(description = "Override max pages for this crawl run", required = false) Integer maxPages) {
         try {
             UUID uuid = parseUuid(sourceId);
             Optional<Source> found = sourceRepository.findById(uuid);
@@ -177,13 +225,101 @@ public class McpToolService {
                 return "Error: Source %s not found.".formatted(sourceId);
             }
             Source source = found.get();
-            return "Recrawl requested for source '%s'. Recrawl functionality will be available in a future update."
-                    .formatted(source.getName());
+
+            if (source.getStatus() == SourceStatus.CRAWLING || source.getStatus() == SourceStatus.UPDATING) {
+                return "Error: Source '%s' is already being crawled (status: %s). Wait for it to finish."
+                        .formatted(source.getName(), source.getStatus());
+            }
+
+            boolean isFullRecrawl = Boolean.TRUE.equals(full);
+
+            if (isFullRecrawl) {
+                ingestionService.clearIngestionState(uuid);
+            }
+
+            CrawlScope scope = buildRecrawlScope(source, allowPatterns, blockPatterns, maxDepth, maxPages);
+
+            source.setStatus(SourceStatus.UPDATING);
+            sourceRepository.save(source);
+
+            dispatchCrawl(uuid, source.getUrl(), scope, isFullRecrawl);
+
+            return "Recrawl started for '%s' (%s mode). Check progress with crawl_status."
+                    .formatted(source.getName(), isFullRecrawl ? "full" : "incremental");
         } catch (IllegalArgumentException e) {
             return "Error: Invalid source ID format. Provide a valid UUID.";
         } catch (Exception e) {
             return "Error requesting recrawl: " + e.getMessage();
         }
+    }
+
+    /**
+     * Dispatches an async crawl via virtual thread. Extracted for testability.
+     */
+    void dispatchCrawl(UUID sourceId, String url, CrawlScope scope, boolean isFullRecrawl) {
+        Thread.startVirtualThread(() -> {
+            try {
+                List<CrawlResult> results = crawlService.crawlSite(sourceId, url, scope);
+                Source freshSource = sourceRepository.findById(sourceId).orElseThrow();
+                freshSource.setStatus(SourceStatus.INDEXED);
+                freshSource.setLastCrawledAt(Instant.now());
+                freshSource.setChunkCount(results.size());
+                sourceRepository.save(freshSource);
+            } catch (Exception e) {
+                log.error("Crawl failed for source {}: {}", sourceId, e.getMessage(), e);
+                sourceRepository.findById(sourceId).ifPresent(freshSource -> {
+                    freshSource.setStatus(SourceStatus.ERROR);
+                    sourceRepository.save(freshSource);
+                });
+            }
+        });
+    }
+
+    private CrawlScope buildRecrawlScope(Source source, String allowPatterns, String blockPatterns,
+                                          Integer maxDepth, Integer maxPages) {
+        CrawlScope defaultScope = CrawlScope.fromSource(source);
+        return new CrawlScope(
+                allowPatterns != null ? parseCommaSeparated(allowPatterns) : defaultScope.allowPatterns(),
+                blockPatterns != null ? parseCommaSeparated(blockPatterns) : defaultScope.blockPatterns(),
+                maxDepth != null ? maxDepth : defaultScope.maxDepth(),
+                maxPages != null ? maxPages : defaultScope.maxPages()
+        );
+    }
+
+    private String formatActiveProgress(Source source, CrawlProgress progress) {
+        Duration elapsed = Duration.between(progress.startedAt(), Instant.now());
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("Source: %s (%s)%n", source.getName(), source.getUrl()));
+        sb.append(String.format("Status: %s%n", progress.status()));
+        sb.append(String.format("Progress: %d/%d pages crawled, %d skipped, %d errors%n",
+                progress.pagesCrawled(), progress.pagesTotal(), progress.pagesSkipped(), progress.errors()));
+        sb.append(String.format("Elapsed: %dm %ds%n", elapsed.toMinutes(), elapsed.toSecondsPart()));
+
+        if (!progress.errorUrls().isEmpty()) {
+            sb.append(String.format("Error URLs:%n"));
+            for (String errorUrl : progress.errorUrls()) {
+                sb.append(String.format("  - %s%n", errorUrl));
+            }
+        }
+
+        if (!progress.filteredUrls().isEmpty()) {
+            sb.append(String.format("Filtered URLs (excluded by scope):%n"));
+            for (String filteredUrl : progress.filteredUrls()) {
+                sb.append(String.format("  - %s%n", filteredUrl));
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private String formatCompletedSummary(Source source) {
+        return String.format("Source: %s (%s)%nStatus: %s%nChunks: %d%nLast crawled: %s",
+                source.getName(),
+                source.getUrl(),
+                source.getStatus(),
+                source.getChunkCount(),
+                source.getLastCrawledAt() != null ? source.getLastCrawledAt().toString() : "never");
     }
 
     private int clampMaxResults(Integer maxResults) {
@@ -195,5 +331,15 @@ public class McpToolService {
 
     private UUID parseUuid(String sourceId) {
         return UUID.fromString(sourceId);
+    }
+
+    private static List<String> parseCommaSeparated(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        return java.util.Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 }

--- a/src/main/java/dev/alexandria/source/Source.java
+++ b/src/main/java/dev/alexandria/source/Source.java
@@ -12,6 +12,8 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -55,6 +57,21 @@ public class Source {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
+    @Column(name = "allow_patterns")
+    private String allowPatterns;
+
+    @Column(name = "block_patterns")
+    private String blockPatterns;
+
+    @Column(name = "max_depth")
+    private Integer maxDepth;
+
+    @Column(name = "max_pages")
+    private Integer maxPages;
+
+    @Column(name = "llms_txt_url")
+    private String llmsTxtUrl;
+
     protected Source() {
         // JPA requires no-arg constructor
     }
@@ -69,6 +86,7 @@ public class Source {
         this.url = url;
         this.name = name;
         this.chunkCount = 0;
+        this.maxPages = 500;
     }
 
     @PrePersist
@@ -124,5 +142,73 @@ public class Source {
 
     public Instant getUpdatedAt() {
         return updatedAt;
+    }
+
+    public String getAllowPatterns() {
+        return allowPatterns;
+    }
+
+    public void setAllowPatterns(String allowPatterns) {
+        this.allowPatterns = allowPatterns;
+    }
+
+    public String getBlockPatterns() {
+        return blockPatterns;
+    }
+
+    public void setBlockPatterns(String blockPatterns) {
+        this.blockPatterns = blockPatterns;
+    }
+
+    public Integer getMaxDepth() {
+        return maxDepth;
+    }
+
+    public void setMaxDepth(Integer maxDepth) {
+        this.maxDepth = maxDepth;
+    }
+
+    public Integer getMaxPages() {
+        return maxPages;
+    }
+
+    public void setMaxPages(Integer maxPages) {
+        this.maxPages = maxPages;
+    }
+
+    public String getLlmsTxtUrl() {
+        return llmsTxtUrl;
+    }
+
+    public void setLlmsTxtUrl(String llmsTxtUrl) {
+        this.llmsTxtUrl = llmsTxtUrl;
+    }
+
+    /**
+     * Parses the comma-separated allow patterns into a list.
+     *
+     * @return list of allow glob patterns, or empty list if none configured
+     */
+    public List<String> getAllowPatternList() {
+        return parseCommaSeparated(allowPatterns);
+    }
+
+    /**
+     * Parses the comma-separated block patterns into a list.
+     *
+     * @return list of block glob patterns, or empty list if none configured
+     */
+    public List<String> getBlockPatternList() {
+        return parseCommaSeparated(blockPatterns);
+    }
+
+    private static List<String> parseCommaSeparated(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 }

--- a/src/main/resources/db/migration/V2__source_scope_columns.sql
+++ b/src/main/resources/db/migration/V2__source_scope_columns.sql
@@ -1,0 +1,11 @@
+-- Add scope configuration columns to sources table for URL filtering during crawl.
+-- allow_patterns / block_patterns: comma-separated glob patterns (e.g. "/docs/**,/api/**")
+-- max_depth: NULL = unlimited depth
+-- max_pages: safety limit, default 500
+-- llms_txt_url: optional manual override for llms.txt location
+
+ALTER TABLE sources ADD COLUMN allow_patterns TEXT;
+ALTER TABLE sources ADD COLUMN block_patterns TEXT;
+ALTER TABLE sources ADD COLUMN max_depth INTEGER;
+ALTER TABLE sources ADD COLUMN max_pages INTEGER DEFAULT 500;
+ALTER TABLE sources ADD COLUMN llms_txt_url TEXT;

--- a/src/test/java/dev/alexandria/crawl/ContentHasherTest.java
+++ b/src/test/java/dev/alexandria/crawl/ContentHasherTest.java
@@ -1,0 +1,38 @@
+package dev.alexandria.crawl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContentHasherTest {
+
+    @Test
+    void hashOfKnownInputMatchesExpected() {
+        String result = ContentHasher.sha256("hello");
+
+        assertThat(result).isEqualTo("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    }
+
+    @Test
+    void sameContentProducesSameHash() {
+        String first = ContentHasher.sha256("deterministic input");
+        String second = ContentHasher.sha256("deterministic input");
+
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void differentContentProducesDifferentHash() {
+        String first = ContentHasher.sha256("content A");
+        String second = ContentHasher.sha256("content B");
+
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    void emptyStringProducesValidHash() {
+        String result = ContentHasher.sha256("");
+
+        assertThat(result).isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    }
+}

--- a/src/test/java/dev/alexandria/crawl/CrawlProgressTrackerTest.java
+++ b/src/test/java/dev/alexandria/crawl/CrawlProgressTrackerTest.java
@@ -1,0 +1,111 @@
+package dev.alexandria.crawl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CrawlProgressTrackerTest {
+
+    private CrawlProgressTracker tracker;
+    private UUID sourceId;
+
+    @BeforeEach
+    void setUp() {
+        tracker = new CrawlProgressTracker();
+        sourceId = UUID.randomUUID();
+    }
+
+    @Test
+    void startCrawlCreatesInitialProgress() {
+        tracker.startCrawl(sourceId, 10);
+
+        CrawlProgress progress = tracker.getProgress(sourceId).orElseThrow();
+
+        assertThat(progress.sourceId()).isEqualTo(sourceId);
+        assertThat(progress.status()).isEqualTo(CrawlProgress.Status.CRAWLING);
+        assertThat(progress.pagesCrawled()).isZero();
+        assertThat(progress.pagesSkipped()).isZero();
+        assertThat(progress.pagesTotal()).isEqualTo(10);
+        assertThat(progress.errors()).isZero();
+        assertThat(progress.errorUrls()).isEmpty();
+        assertThat(progress.filteredUrls()).isEmpty();
+        assertThat(progress.startedAt()).isNotNull();
+    }
+
+    @Test
+    void recordPageCrawledIncrementsCount() {
+        tracker.startCrawl(sourceId, 5);
+
+        tracker.recordPageCrawled(sourceId);
+        tracker.recordPageCrawled(sourceId);
+
+        assertThat(tracker.getProgress(sourceId).orElseThrow().pagesCrawled()).isEqualTo(2);
+    }
+
+    @Test
+    void recordPageSkippedIncrementsCount() {
+        tracker.startCrawl(sourceId, 5);
+
+        tracker.recordPageSkipped(sourceId);
+
+        assertThat(tracker.getProgress(sourceId).orElseThrow().pagesSkipped()).isEqualTo(1);
+    }
+
+    @Test
+    void recordErrorAddsUrlToList() {
+        tracker.startCrawl(sourceId, 5);
+
+        tracker.recordError(sourceId, "https://example.com/broken");
+
+        CrawlProgress progress = tracker.getProgress(sourceId).orElseThrow();
+        assertThat(progress.errors()).isEqualTo(1);
+        assertThat(progress.errorUrls()).containsExactly("https://example.com/broken");
+    }
+
+    @Test
+    void recordFilteredAddsUrlToList() {
+        tracker.startCrawl(sourceId, 5);
+
+        tracker.recordFiltered(sourceId, "https://example.com/blocked");
+
+        CrawlProgress progress = tracker.getProgress(sourceId).orElseThrow();
+        assertThat(progress.filteredUrls()).containsExactly("https://example.com/blocked");
+    }
+
+    @Test
+    void completeCrawlSetsCompletedStatus() {
+        tracker.startCrawl(sourceId, 5);
+
+        tracker.completeCrawl(sourceId);
+
+        assertThat(tracker.getProgress(sourceId).orElseThrow().status())
+                .isEqualTo(CrawlProgress.Status.COMPLETED);
+    }
+
+    @Test
+    void failCrawlSetsFailedStatus() {
+        tracker.startCrawl(sourceId, 5);
+
+        tracker.failCrawl(sourceId);
+
+        assertThat(tracker.getProgress(sourceId).orElseThrow().status())
+                .isEqualTo(CrawlProgress.Status.FAILED);
+    }
+
+    @Test
+    void getProgressReturnsEmptyForUnknownSource() {
+        assertThat(tracker.getProgress(UUID.randomUUID())).isEmpty();
+    }
+
+    @Test
+    void removeCrawlCleansUpMemory() {
+        tracker.startCrawl(sourceId, 5);
+
+        tracker.removeCrawl(sourceId);
+
+        assertThat(tracker.getProgress(sourceId)).isEmpty();
+    }
+}

--- a/src/test/java/dev/alexandria/crawl/CrawlScopeTest.java
+++ b/src/test/java/dev/alexandria/crawl/CrawlScopeTest.java
@@ -1,0 +1,42 @@
+package dev.alexandria.crawl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CrawlScopeTest {
+
+    @Test
+    void nullPatternsDefaultToEmptyLists() {
+        var scope = new CrawlScope(null, null, null, 100);
+
+        assertThat(scope.allowPatterns()).isEmpty();
+        assertThat(scope.blockPatterns()).isEmpty();
+    }
+
+    @Test
+    void patternsAreDefensivelyCopied() {
+        var allowList = new ArrayList<>(List.of("/docs/**"));
+        var blockList = new ArrayList<>(List.of("/docs/archive/**"));
+        var scope = new CrawlScope(allowList, blockList, 3, 50);
+
+        allowList.add("/api/**");
+        blockList.add("/internal/**");
+
+        assertThat(scope.allowPatterns()).containsExactly("/docs/**");
+        assertThat(scope.blockPatterns()).containsExactly("/docs/archive/**");
+    }
+
+    @Test
+    void withDefaultsReturnsEmptyScope() {
+        var scope = CrawlScope.withDefaults(200);
+
+        assertThat(scope.allowPatterns()).isEmpty();
+        assertThat(scope.blockPatterns()).isEmpty();
+        assertThat(scope.maxDepth()).isNull();
+        assertThat(scope.maxPages()).isEqualTo(200);
+    }
+}

--- a/src/test/java/dev/alexandria/crawl/CrawlServiceTest.java
+++ b/src/test/java/dev/alexandria/crawl/CrawlServiceTest.java
@@ -35,7 +35,7 @@ class CrawlServiceTest {
         String rootUrl = "https://docs.example.com";
         var discovery = new PageDiscoveryService.DiscoveryResult(
                 List.of("https://docs.example.com/guide"),
-                PageDiscoveryService.DiscoveryMethod.SITEMAP);
+                PageDiscoveryService.DiscoveryMethod.SITEMAP, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         when(crawl4AiClient.crawl("https://docs.example.com/guide"))
                 .thenReturn(new CrawlResult("https://docs.example.com/guide", "# Guide", List.of(), true, null));
@@ -52,7 +52,7 @@ class CrawlServiceTest {
         String rootUrl = "https://docs.example.com";
         var discovery = new PageDiscoveryService.DiscoveryResult(
                 List.of(),
-                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL);
+                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         when(crawl4AiClient.crawl("https://docs.example.com/"))
                 .thenReturn(new CrawlResult("https://docs.example.com/",
@@ -73,7 +73,7 @@ class CrawlServiceTest {
         String rootUrl = "https://docs.example.com";
         var discovery = new PageDiscoveryService.DiscoveryResult(
                 List.of("https://docs.example.com/page1"),
-                PageDiscoveryService.DiscoveryMethod.SITEMAP);
+                PageDiscoveryService.DiscoveryMethod.SITEMAP, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         when(crawl4AiClient.crawl("https://docs.example.com/page1"))
                 .thenReturn(new CrawlResult("https://docs.example.com/page1",
@@ -92,7 +92,7 @@ class CrawlServiceTest {
                 List.of("https://docs.example.com/p1",
                         "https://docs.example.com/p2",
                         "https://docs.example.com/p3"),
-                PageDiscoveryService.DiscoveryMethod.SITEMAP);
+                PageDiscoveryService.DiscoveryMethod.SITEMAP, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         when(crawl4AiClient.crawl("https://docs.example.com/p1"))
                 .thenReturn(new CrawlResult("https://docs.example.com/p1", "# P1", List.of(), true, null));
@@ -111,7 +111,7 @@ class CrawlServiceTest {
         var discovery = new PageDiscoveryService.DiscoveryResult(
                 List.of("https://docs.example.com/fail",
                         "https://docs.example.com/ok"),
-                PageDiscoveryService.DiscoveryMethod.SITEMAP);
+                PageDiscoveryService.DiscoveryMethod.SITEMAP, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         when(crawl4AiClient.crawl("https://docs.example.com/fail"))
                 .thenReturn(new CrawlResult("https://docs.example.com/fail", null, List.of(), false, "404"));
@@ -130,7 +130,7 @@ class CrawlServiceTest {
         var discovery = new PageDiscoveryService.DiscoveryResult(
                 List.of("https://docs.example.com/error",
                         "https://docs.example.com/ok"),
-                PageDiscoveryService.DiscoveryMethod.SITEMAP);
+                PageDiscoveryService.DiscoveryMethod.SITEMAP, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         when(crawl4AiClient.crawl("https://docs.example.com/error"))
                 .thenThrow(new RuntimeException("Connection refused"));
@@ -148,7 +148,7 @@ class CrawlServiceTest {
         String rootUrl = "https://docs.example.com";
         var discovery = new PageDiscoveryService.DiscoveryResult(
                 List.of(),
-                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL);
+                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         // Root page returns a link that will normalize to the same URL as root
         when(crawl4AiClient.crawl("https://docs.example.com/"))
@@ -169,7 +169,7 @@ class CrawlServiceTest {
         String rootUrl = "https://docs.example.com";
         var discovery = new PageDiscoveryService.DiscoveryResult(
                 List.of(),
-                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL);
+                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         // Root page returns links with fragments that normalize to the same page
         when(crawl4AiClient.crawl("https://docs.example.com/"))
@@ -192,7 +192,7 @@ class CrawlServiceTest {
         String rootUrl = "https://docs.example.com";
         var discovery = new PageDiscoveryService.DiscoveryResult(
                 List.of(),
-                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL);
+                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         when(crawl4AiClient.crawl("https://docs.example.com/"))
                 .thenReturn(new CrawlResult("https://docs.example.com/", "# Home", List.of(), true, null));
@@ -208,7 +208,7 @@ class CrawlServiceTest {
         String rootUrl = "https://docs.example.com";
         var discovery = new PageDiscoveryService.DiscoveryResult(
                 List.of(),
-                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL);
+                PageDiscoveryService.DiscoveryMethod.LINK_CRAWL, null);
         when(pageDiscoveryService.discoverUrls(rootUrl)).thenReturn(discovery);
         when(crawl4AiClient.crawl("https://docs.example.com/"))
                 .thenReturn(new CrawlResult("https://docs.example.com/",

--- a/src/test/java/dev/alexandria/crawl/LlmsTxtParserTest.java
+++ b/src/test/java/dev/alexandria/crawl/LlmsTxtParserTest.java
@@ -1,0 +1,251 @@
+package dev.alexandria.crawl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LlmsTxtParserTest {
+
+    @Test
+    void parseUrlsExtractsLinksFromStandardFormat() {
+        String content = """
+                # Spring Boot Documentation
+
+                ## Getting Started
+
+                - [Quick Start](https://docs.spring.io/boot/quick-start)
+                - [Installation](https://docs.spring.io/boot/install)
+                """;
+
+        var urls = LlmsTxtParser.parseUrls(content);
+
+        assertThat(urls).containsExactly(
+                "https://docs.spring.io/boot/quick-start",
+                "https://docs.spring.io/boot/install"
+        );
+    }
+
+    @Test
+    void parseUrlsHandlesLinksWithDescriptions() {
+        String content = """
+                # Docs
+
+                - [Quick Start](https://docs.spring.io/boot/quick-start): How to get started
+                - [Config](https://docs.spring.io/boot/config): Configuration reference
+                """;
+
+        var urls = LlmsTxtParser.parseUrls(content);
+
+        assertThat(urls).containsExactly(
+                "https://docs.spring.io/boot/quick-start",
+                "https://docs.spring.io/boot/config"
+        );
+    }
+
+    @Test
+    void parseUrlsIgnoresHeadersAndBlankLines() {
+        String content = """
+                # Spring Boot Documentation
+
+                ## Getting Started
+
+                - [Quick Start](https://docs.spring.io/boot/quick-start)
+
+                ## Reference
+
+                - [Config](https://docs.spring.io/boot/config)
+                """;
+
+        var urls = LlmsTxtParser.parseUrls(content);
+
+        assertThat(urls).containsExactly(
+                "https://docs.spring.io/boot/quick-start",
+                "https://docs.spring.io/boot/config"
+        );
+    }
+
+    @Test
+    void parseUrlsIgnoresBlockquotes() {
+        String content = """
+                # Spring Boot Documentation
+
+                > Spring Boot reference documentation
+
+                - [Quick Start](https://docs.spring.io/boot/quick-start)
+                """;
+
+        var urls = LlmsTxtParser.parseUrls(content);
+
+        assertThat(urls).containsExactly("https://docs.spring.io/boot/quick-start");
+    }
+
+    @Test
+    void parseUrlsHandlesLinksWithoutDash() {
+        String content = """
+                # Docs
+
+                [Quick Start](https://docs.spring.io/boot/quick-start)
+                [Installation](https://docs.spring.io/boot/install)
+                """;
+
+        var urls = LlmsTxtParser.parseUrls(content);
+
+        assertThat(urls).containsExactly(
+                "https://docs.spring.io/boot/quick-start",
+                "https://docs.spring.io/boot/install"
+        );
+    }
+
+    @Test
+    void parseUrlsReturnsEmptyForNoLinks() {
+        String content = """
+                This is just plain text.
+                No markdown links here.
+                Just some paragraphs.
+                """;
+
+        var urls = LlmsTxtParser.parseUrls(content);
+
+        assertThat(urls).isEmpty();
+    }
+
+    @Test
+    void parseUrlsReturnsEmptyForNullOrEmpty() {
+        assertThat(LlmsTxtParser.parseUrls(null)).isEmpty();
+        assertThat(LlmsTxtParser.parseUrls("")).isEmpty();
+        assertThat(LlmsTxtParser.parseUrls("   ")).isEmpty();
+    }
+
+    @Test
+    void parseUrlsExtractsMultipleSections() {
+        String content = """
+                # Spring Boot Documentation
+
+                > Spring Boot reference documentation
+
+                ## Getting Started
+
+                - [Quick Start](https://docs.spring.io/boot/quick-start): How to get started
+                - [Installation](https://docs.spring.io/boot/install)
+
+                ## Reference
+
+                - [Configuration](https://docs.spring.io/boot/config)
+                - [Actuator](https://docs.spring.io/boot/actuator): Production features
+                """;
+
+        var urls = LlmsTxtParser.parseUrls(content);
+
+        assertThat(urls).containsExactly(
+                "https://docs.spring.io/boot/quick-start",
+                "https://docs.spring.io/boot/install",
+                "https://docs.spring.io/boot/config",
+                "https://docs.spring.io/boot/actuator"
+        );
+    }
+
+    @Test
+    void isLlmsTxtContentDetectsLinkIndex() {
+        String content = """
+                # Spring Boot Documentation
+
+                > Summary
+
+                - [Quick Start](https://docs.spring.io/boot/quick-start)
+                - [Installation](https://docs.spring.io/boot/install)
+                """;
+
+        boolean result = LlmsTxtParser.isLlmsTxtContent(content);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isLlmsTxtContentRejectsPlainMarkdown() {
+        String content = """
+                # Getting Started with Spring Boot
+
+                Spring Boot makes it easy to create stand-alone, production-grade Spring based
+                Applications that you can just run. We take an opinionated view of the Spring
+                platform and third-party libraries so you can get started with minimum fuss.
+                Most Spring Boot applications need minimal Spring configuration.
+
+                ## Features
+
+                Spring Boot provides a range of features that address common development needs.
+                For example, embedded servers, security, metrics, health checks, externalized
+                configuration, and more. Here is a detailed description of each feature and
+                how to use them effectively in your applications.
+
+                ## System Requirements
+
+                Spring Boot 3.x requires Java 17 or later. It has been tested with the JDK
+                distributions from multiple vendors. Make sure you have the correct version
+                installed before proceeding.
+                """;
+
+        boolean result = LlmsTxtParser.isLlmsTxtContent(content);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void parseDistinguishesLlmsTxtFromLlmsFullTxt() {
+        // llms.txt: link index
+        String llmsTxt = """
+                # Spring Boot Documentation
+
+                > Summary
+
+                - [Quick Start](https://docs.spring.io/boot/quick-start)
+                - [Installation](https://docs.spring.io/boot/install)
+                """;
+
+        LlmsTxtParser.LlmsTxtResult indexResult = LlmsTxtParser.parse(llmsTxt);
+
+        assertThat(indexResult.urls()).containsExactly(
+                "https://docs.spring.io/boot/quick-start",
+                "https://docs.spring.io/boot/install"
+        );
+        assertThat(indexResult.rawContent()).isEmpty();
+        assertThat(indexResult.isFullContent()).isFalse();
+
+        // llms-full.txt: raw markdown content with some inline links
+        String llmsFullTxt = """
+                # Spring Boot Documentation
+
+                Spring Boot makes it easy to create stand-alone, production-grade Spring based
+                Applications that you can just run. We take an opinionated view of the Spring
+                platform and third-party libraries so you can get started with minimum fuss.
+                Most Spring Boot applications need minimal Spring configuration.
+
+                ## Getting Started
+
+                To get started with Spring Boot, you need to install Java 17 or later.
+                Download the latest version from the [official site](https://adoptium.net).
+
+                ## Features
+
+                Spring Boot provides a range of features that address common development needs.
+                For example, embedded servers, security, metrics, health checks, externalized
+                configuration, and more. Here is a detailed description of each feature and
+                how to use them effectively in your applications. Visit the
+                [reference docs](https://docs.spring.io/boot/reference) for details.
+
+                ## System Requirements
+
+                Spring Boot 3.x requires Java 17 or later. It has been tested with the JDK
+                distributions from multiple vendors. Make sure you have the correct version
+                installed before proceeding.
+                """;
+
+        LlmsTxtParser.LlmsTxtResult fullResult = LlmsTxtParser.parse(llmsFullTxt);
+
+        assertThat(fullResult.urls()).containsExactly(
+                "https://adoptium.net",
+                "https://docs.spring.io/boot/reference"
+        );
+        assertThat(fullResult.rawContent()).isEqualTo(llmsFullTxt);
+        assertThat(fullResult.isFullContent()).isTrue();
+    }
+}

--- a/src/test/java/dev/alexandria/crawl/PageDiscoveryServiceTest.java
+++ b/src/test/java/dev/alexandria/crawl/PageDiscoveryServiceTest.java
@@ -1,15 +1,20 @@
 package dev.alexandria.crawl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
 
 @ExtendWith(MockitoExtension.class)
 class PageDiscoveryServiceTest {
@@ -17,11 +22,38 @@ class PageDiscoveryServiceTest {
     @Mock
     private SitemapParser sitemapParser;
 
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    /** URL -> response body mapping for HTTP stubbing. Empty map = all return null. */
+    private final Map<String, String> httpResponses = new HashMap<>();
+
     private PageDiscoveryService pageDiscoveryService;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUp() {
-        pageDiscoveryService = new PageDiscoveryService(sitemapParser);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        var uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        when(restClient.get()).thenReturn(uriSpec);
+
+        when(uriSpec.uri(any(String.class))).thenAnswer(invocation -> {
+            String requestedUri = invocation.getArgument(0, String.class);
+            String content = httpResponses.get(requestedUri);
+
+            var headersSpec = mock(RestClient.RequestHeadersSpec.class);
+            var responseSpec = mock(RestClient.ResponseSpec.class);
+            when(headersSpec.retrieve()).thenReturn(responseSpec);
+            when(responseSpec.body(String.class)).thenReturn(content);
+            return headersSpec;
+        });
+
+        httpResponses.clear();
+        pageDiscoveryService = new PageDiscoveryService(sitemapParser, restClientBuilder);
     }
 
     @Test
@@ -36,6 +68,7 @@ class PageDiscoveryServiceTest {
         assertThat(result.urls()).containsExactly(
                 "https://docs.example.com/page1",
                 "https://docs.example.com/page2");
+        assertThat(result.llmsFullContent()).isNull();
     }
 
     @Test
@@ -47,6 +80,7 @@ class PageDiscoveryServiceTest {
 
         assertThat(result.method()).isEqualTo(PageDiscoveryService.DiscoveryMethod.LINK_CRAWL);
         assertThat(result.urls()).isEmpty();
+        assertThat(result.llmsFullContent()).isNull();
     }
 
     @Test
@@ -94,13 +128,82 @@ class PageDiscoveryServiceTest {
 
         PageDiscoveryService.DiscoveryResult result = pageDiscoveryService.discoverUrls(rootUrl);
 
-        // After filtering, no same-site URLs remain, but method is still SITEMAP
-        // because sitemap returned URLs (they just were all external)
-        // Actually let's check: the filter removes all, leaving empty filtered list
-        // But the original sitemapUrls was not empty, so we enter the if-branch
-        // filtered list is empty? No -- the code checks !sitemapUrls.isEmpty()
-        // and returns a DiscoveryResult with the filtered list and SITEMAP method
         assertThat(result.method()).isEqualTo(PageDiscoveryService.DiscoveryMethod.SITEMAP);
         assertThat(result.urls()).isEmpty();
+    }
+
+    @Test
+    void llmsTxtFoundReturnsUrls() {
+        String rootUrl = "https://docs.example.com";
+        String llmsTxtContent = """
+                # Example Docs
+
+                > A documentation site
+
+                ## Guides
+
+                - [Getting Started](https://docs.example.com/start): Quick start guide
+                - [API Reference](https://docs.example.com/api): Full API docs
+                """;
+
+        httpResponses.put("https://docs.example.com/llms.txt", llmsTxtContent);
+
+        PageDiscoveryService.DiscoveryResult result = pageDiscoveryService.discoverUrls(rootUrl);
+
+        assertThat(result.method()).isEqualTo(PageDiscoveryService.DiscoveryMethod.LLMS_TXT);
+        assertThat(result.urls()).containsExactly(
+                "https://docs.example.com/start",
+                "https://docs.example.com/api");
+        assertThat(result.llmsFullContent()).isNull();
+    }
+
+    @Test
+    void llmsFullTxtFoundReturnsContentAndUrls() {
+        String rootUrl = "https://docs.example.com";
+        String llmsFullContent = """
+                # Example Docs
+
+                This is a comprehensive documentation page with all the content.
+
+                Some paragraph about getting started with the framework.
+
+                Another paragraph about configuration options and best practices.
+
+                See also [API Reference](https://docs.example.com/api) for more details.
+                """;
+
+        httpResponses.put("https://docs.example.com/llms-full.txt", llmsFullContent);
+
+        PageDiscoveryService.DiscoveryResult result = pageDiscoveryService.discoverUrls(rootUrl);
+
+        assertThat(result.method()).isEqualTo(PageDiscoveryService.DiscoveryMethod.LLMS_FULL_TXT);
+        assertThat(result.urls()).containsExactly("https://docs.example.com/api");
+        assertThat(result.llmsFullContent()).isEqualTo(llmsFullContent);
+    }
+
+    @Test
+    void llmsTxtNotFoundFallsToSitemap() {
+        String rootUrl = "https://docs.example.com";
+        // No httpResponses entries = all return null (llms.txt not found)
+        when(sitemapParser.discoverFromSitemap(rootUrl))
+                .thenReturn(List.of("https://docs.example.com/from-sitemap"));
+
+        PageDiscoveryService.DiscoveryResult result = pageDiscoveryService.discoverUrls(rootUrl);
+
+        assertThat(result.method()).isEqualTo(PageDiscoveryService.DiscoveryMethod.SITEMAP);
+        assertThat(result.urls()).containsExactly("https://docs.example.com/from-sitemap");
+    }
+
+    @Test
+    void noLlmsTxtNoSitemapFallsToLinkCrawl() {
+        String rootUrl = "https://docs.example.com";
+        // No httpResponses entries = all return null (llms.txt not found)
+        when(sitemapParser.discoverFromSitemap(rootUrl)).thenReturn(List.of());
+
+        PageDiscoveryService.DiscoveryResult result = pageDiscoveryService.discoverUrls(rootUrl);
+
+        assertThat(result.method()).isEqualTo(PageDiscoveryService.DiscoveryMethod.LINK_CRAWL);
+        assertThat(result.urls()).isEmpty();
+        assertThat(result.llmsFullContent()).isNull();
     }
 }

--- a/src/test/java/dev/alexandria/crawl/UrlScopeFilterTest.java
+++ b/src/test/java/dev/alexandria/crawl/UrlScopeFilterTest.java
@@ -1,0 +1,84 @@
+package dev.alexandria.crawl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UrlScopeFilterTest {
+
+    private static final String ROOT = "https://docs.example.com/docs";
+
+    @Test
+    void externalUrlIsRejected() {
+        var scope = CrawlScope.withDefaults(100);
+
+        boolean result = UrlScopeFilter.isAllowed("https://other-site.com/page", ROOT, scope);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void sameSiteUrlWithNoScopeIsAllowed() {
+        var scope = CrawlScope.withDefaults(100);
+
+        boolean result = UrlScopeFilter.isAllowed("https://docs.example.com/anything", ROOT, scope);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void urlMatchingAllowPatternIsAllowed() {
+        var scope = new CrawlScope(List.of("/docs/**"), List.of(), null, 100);
+
+        boolean result = UrlScopeFilter.isAllowed("https://docs.example.com/docs/api/v2", ROOT, scope);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void urlNotMatchingAllowPatternIsRejected() {
+        var scope = new CrawlScope(List.of("/docs/**"), List.of(), null, 100);
+
+        boolean result = UrlScopeFilter.isAllowed("https://docs.example.com/blog/post", ROOT, scope);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void blockPatternTakesPriorityOverAllow() {
+        var scope = new CrawlScope(List.of("/docs/**"), List.of("/docs/archive/**"), null, 100);
+
+        boolean result = UrlScopeFilter.isAllowed("https://docs.example.com/docs/archive/old", ROOT, scope);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void rootPathSlashIsAllowed() {
+        var scope = CrawlScope.withDefaults(100);
+
+        boolean result = UrlScopeFilter.isAllowed("https://docs.example.com/", ROOT, scope);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void multipleAllowPatternsAnyMatch() {
+        var scope = new CrawlScope(List.of("/docs/**", "/api/**"), List.of(), null, 100);
+
+        boolean result = UrlScopeFilter.isAllowed("https://docs.example.com/api/reference", ROOT, scope);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void malformedUrlReturnsFalse() {
+        var scope = CrawlScope.withDefaults(100);
+
+        boolean result = UrlScopeFilter.isAllowed("not a valid url ://broken", ROOT, scope);
+
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/dev/alexandria/fixture/SourceBuilder.java
+++ b/src/test/java/dev/alexandria/fixture/SourceBuilder.java
@@ -20,6 +20,11 @@ public final class SourceBuilder {
     private SourceStatus status = SourceStatus.PENDING;
     private Instant lastCrawledAt;
     private int chunkCount = 0;
+    private String allowPatterns;
+    private String blockPatterns;
+    private Integer maxDepth;
+    private Integer maxPages;
+    private String llmsTxtUrl;
 
     public SourceBuilder url(String url) {
         this.url = url;
@@ -46,6 +51,31 @@ public final class SourceBuilder {
         return this;
     }
 
+    public SourceBuilder allowPatterns(String allowPatterns) {
+        this.allowPatterns = allowPatterns;
+        return this;
+    }
+
+    public SourceBuilder blockPatterns(String blockPatterns) {
+        this.blockPatterns = blockPatterns;
+        return this;
+    }
+
+    public SourceBuilder maxDepth(Integer maxDepth) {
+        this.maxDepth = maxDepth;
+        return this;
+    }
+
+    public SourceBuilder maxPages(Integer maxPages) {
+        this.maxPages = maxPages;
+        return this;
+    }
+
+    public SourceBuilder llmsTxtUrl(String llmsTxtUrl) {
+        this.llmsTxtUrl = llmsTxtUrl;
+        return this;
+    }
+
     public Source build() {
         Source source = new Source(url, name);
         source.setStatus(status);
@@ -53,6 +83,21 @@ public final class SourceBuilder {
             source.setLastCrawledAt(lastCrawledAt);
         }
         source.setChunkCount(chunkCount);
+        if (allowPatterns != null) {
+            source.setAllowPatterns(allowPatterns);
+        }
+        if (blockPatterns != null) {
+            source.setBlockPatterns(blockPatterns);
+        }
+        if (maxDepth != null) {
+            source.setMaxDepth(maxDepth);
+        }
+        if (maxPages != null) {
+            source.setMaxPages(maxPages);
+        }
+        if (llmsTxtUrl != null) {
+            source.setLlmsTxtUrl(llmsTxtUrl);
+        }
         return source;
     }
 }

--- a/src/test/java/dev/alexandria/ingestion/IngestionServiceTest.java
+++ b/src/test/java/dev/alexandria/ingestion/IngestionServiceTest.java
@@ -1,7 +1,5 @@
 package dev.alexandria.ingestion;
 
-import dev.alexandria.crawl.ContentHasher;
-import dev.alexandria.crawl.CrawlResult;
 import dev.alexandria.ingestion.chunking.ContentType;
 import dev.alexandria.ingestion.chunking.DocumentChunkData;
 import dev.alexandria.ingestion.chunking.MarkdownChunker;
@@ -15,20 +13,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,116 +52,7 @@ class IngestionServiceTest {
     @Captor
     ArgumentCaptor<List<Embedding>> embeddingsCaptor;
 
-    // --- Happy path ---
-
-    @Test
-    void ingestChunksAndStoresEmbeddingsForAllPages() {
-        var page = new CrawlResult("https://docs.example.com/guide", "# Guide\nSome content", List.of(), true, null);
-        var chunkData = new DocumentChunkData("Some content", "https://docs.example.com/guide",
-                "guide", ContentType.PROSE, "2026-01-01T00:00:00Z", null);
-        when(chunker.chunk(eq("# Guide\nSome content"), eq("https://docs.example.com/guide"), anyString()))
-                .thenReturn(List.of(chunkData));
-        Embedding embedding = Embedding.from(new float[]{0.1f, 0.2f});
-        when(embeddingModel.embedAll(any())).thenReturn(Response.from(List.of(embedding)));
-
-        int result = ingestionService.ingest(List.of(page));
-
-        assertThat(result).isEqualTo(1);
-        verify(embeddingStore).addAll(embeddingsCaptor.capture(), segmentsCaptor.capture());
-        assertThat(embeddingsCaptor.getValue()).containsExactly(embedding);
-        assertThat(segmentsCaptor.getValue()).hasSize(1);
-        assertThat(segmentsCaptor.getValue().getFirst().text()).isEqualTo("Some content");
-    }
-
-    // --- Pipeline orchestration ---
-
-    @Test
-    void ingestPassesSourceUrlAndMarkdownToChunker() {
-        var page = new CrawlResult("https://example.com/api", "# API Reference", List.of(), true, null);
-        when(chunker.chunk(anyString(), anyString(), anyString())).thenReturn(List.of());
-
-        ingestionService.ingest(List.of(page));
-
-        verify(chunker).chunk(eq("# API Reference"), eq("https://example.com/api"), anyString());
-    }
-
-    @Test
-    void ingestCreatesTextSegmentsWithCorrectMetadata() {
-        var page = new CrawlResult("https://docs.spring.io/config", "# Config\nSetup instructions", List.of(), true, null);
-        var chunkData = new DocumentChunkData("Setup instructions", "https://docs.spring.io/config",
-                "config/setup", ContentType.PROSE, "2026-02-15T10:30:00Z", null);
-        when(chunker.chunk(anyString(), anyString(), anyString())).thenReturn(List.of(chunkData));
-        when(embeddingModel.embedAll(any())).thenReturn(Response.from(List.of(Embedding.from(new float[]{0.5f}))));
-
-        ingestionService.ingest(List.of(page));
-
-        verify(embeddingStore).addAll(any(), segmentsCaptor.capture());
-        TextSegment segment = segmentsCaptor.getValue().getFirst();
-        assertThat(segment.metadata().getString("source_url")).isEqualTo("https://docs.spring.io/config");
-        assertThat(segment.metadata().getString("section_path")).isEqualTo("config/setup");
-        assertThat(segment.metadata().getString("content_type")).isEqualTo("prose");
-        assertThat(segment.metadata().getString("last_updated")).isEqualTo("2026-02-15T10:30:00Z");
-    }
-
-    @Test
-    void ingestCreatesTextSegmentsWithLanguageForCodeChunks() {
-        var page = new CrawlResult("https://docs.example.com/code", "```java\nSystem.out.println();\n```", List.of(), true, null);
-        var codeChunk = new DocumentChunkData("System.out.println();", "https://docs.example.com/code",
-                "code", ContentType.CODE, "2026-01-01T00:00:00Z", "java");
-        when(chunker.chunk(anyString(), anyString(), anyString())).thenReturn(List.of(codeChunk));
-        when(embeddingModel.embedAll(any())).thenReturn(Response.from(List.of(Embedding.from(new float[]{0.3f}))));
-
-        ingestionService.ingest(List.of(page));
-
-        verify(embeddingStore).addAll(any(), segmentsCaptor.capture());
-        TextSegment segment = segmentsCaptor.getValue().getFirst();
-        assertThat(segment.metadata().getString("content_type")).isEqualTo("code");
-        assertThat(segment.metadata().getString("language")).isEqualTo("java");
-    }
-
-    @Test
-    void ingestAccumulatesChunkCountAcrossMultiplePages() {
-        var page1 = new CrawlResult("https://example.com/a", "# Page A", List.of(), true, null);
-        var page2 = new CrawlResult("https://example.com/b", "# Page B", List.of(), true, null);
-        var chunk1 = new DocumentChunkData("text A", "https://example.com/a", "a", ContentType.PROSE, "2026-01-01T00:00:00Z", null);
-        var chunk2a = new DocumentChunkData("text B1", "https://example.com/b", "b", ContentType.PROSE, "2026-01-01T00:00:00Z", null);
-        var chunk2b = new DocumentChunkData("text B2", "https://example.com/b", "b/sub", ContentType.PROSE, "2026-01-01T00:00:00Z", null);
-        when(chunker.chunk(eq("# Page A"), anyString(), anyString())).thenReturn(List.of(chunk1));
-        when(chunker.chunk(eq("# Page B"), anyString(), anyString())).thenReturn(List.of(chunk2a, chunk2b));
-        when(embeddingModel.embedAll(any())).thenAnswer(invocation -> {
-            List<TextSegment> segments = invocation.getArgument(0);
-            List<Embedding> embeddings = segments.stream()
-                    .map(s -> Embedding.from(new float[]{0.1f}))
-                    .toList();
-            return Response.from(embeddings);
-        });
-
-        int result = ingestionService.ingest(List.of(page1, page2));
-
-        assertThat(result).isEqualTo(3);
-    }
-
-    // --- Edge cases ---
-
-    @Test
-    void ingestEmptyMarkdownProducesNoChunks() {
-        var page = new CrawlResult("https://example.com/empty", "", List.of(), true, null);
-        when(chunker.chunk(eq(""), anyString(), anyString())).thenReturn(List.of());
-
-        int result = ingestionService.ingest(List.of(page));
-
-        assertThat(result).isEqualTo(0);
-        verify(embeddingStore, never()).addAll(any(), any());
-    }
-
-    @Test
-    void ingestEmptyPageListReturnsZero() {
-        int result = ingestionService.ingest(List.of());
-
-        assertThat(result).isEqualTo(0);
-    }
-
-    // --- Single-page convenience method ---
+    // --- Single-page ingestion ---
 
     @Test
     void ingestPageChunksAndStoresWithProvidedTimestamp() {
@@ -193,92 +79,69 @@ class IngestionServiceTest {
         verify(embeddingStore, never()).addAll(any(), any());
     }
 
-    // --- Incremental ingestion ---
-
     @Test
-    void ingestPageIncrementalSkipsUnchangedContent() {
-        UUID sourceId = UUID.randomUUID();
-        String url = "https://example.com/page";
-        String markdown = "# Hello";
-        String hash = ContentHasher.sha256(markdown);
-        var existingState = new IngestionState(sourceId, "https://example.com/page", hash);
-        when(ingestionStateRepository.findBySourceIdAndPageUrl(sourceId, "https://example.com/page"))
-                .thenReturn(Optional.of(existingState));
+    void ingestPageCreatesTextSegmentsWithCorrectMetadata() {
+        var chunkData = new DocumentChunkData("Setup instructions", "https://docs.spring.io/config",
+                "config/setup", ContentType.PROSE, "2026-02-15T10:30:00Z", null);
+        when(chunker.chunk(anyString(), anyString(), anyString())).thenReturn(List.of(chunkData));
+        when(embeddingModel.embedAll(any())).thenReturn(Response.from(List.of(Embedding.from(new float[]{0.5f}))));
 
-        IngestionService.IngestResult result = ingestionService.ingestPageIncremental(sourceId, url, markdown);
+        ingestionService.ingestPage("# Config\nSetup instructions", "https://docs.spring.io/config", "2026-02-15T10:30:00Z");
 
-        assertThat(result.skipped()).isTrue();
-        assertThat(result.changed()).isFalse();
-        assertThat(result.chunksStored()).isZero();
-        verify(embeddingStore, never()).removeAll(any(Filter.class));
-        verify(chunker, never()).chunk(anyString(), anyString(), anyString());
+        verify(embeddingStore).addAll(any(), segmentsCaptor.capture());
+        TextSegment segment = segmentsCaptor.getValue().getFirst();
+        assertThat(segment.metadata().getString("source_url")).isEqualTo("https://docs.spring.io/config");
+        assertThat(segment.metadata().getString("section_path")).isEqualTo("config/setup");
+        assertThat(segment.metadata().getString("content_type")).isEqualTo("prose");
+        assertThat(segment.metadata().getString("last_updated")).isEqualTo("2026-02-15T10:30:00Z");
     }
 
     @Test
-    void ingestPageIncrementalReprocessesChangedContent() {
-        UUID sourceId = UUID.randomUUID();
-        String url = "https://example.com/page";
-        String oldHash = ContentHasher.sha256("old content");
-        var existingState = new IngestionState(sourceId, "https://example.com/page", oldHash);
-        when(ingestionStateRepository.findBySourceIdAndPageUrl(sourceId, "https://example.com/page"))
-                .thenReturn(Optional.of(existingState));
-        var chunkData = new DocumentChunkData("new content", "https://example.com/page",
-                "section", ContentType.PROSE, "2026-01-01T00:00:00Z", null);
-        when(chunker.chunk(eq("# New content"), eq("https://example.com/page"), anyString()))
-                .thenReturn(List.of(chunkData));
-        when(embeddingModel.embedAll(any())).thenReturn(Response.from(List.of(Embedding.from(new float[]{0.1f}))));
-
-        IngestionService.IngestResult result = ingestionService.ingestPageIncremental(sourceId, url, "# New content");
-
-        assertThat(result.skipped()).isFalse();
-        assertThat(result.changed()).isTrue();
-        assertThat(result.chunksStored()).isEqualTo(1);
-        verify(embeddingStore).removeAll(any(Filter.class));
-        verify(ingestionStateRepository).save(existingState);
-    }
-
-    @Test
-    void ingestPageIncrementalCreatesNewStateForNewPage() {
-        UUID sourceId = UUID.randomUUID();
-        String url = "https://example.com/new-page";
-        when(ingestionStateRepository.findBySourceIdAndPageUrl(sourceId, "https://example.com/new-page"))
-                .thenReturn(Optional.empty());
-        var chunkData = new DocumentChunkData("content", "https://example.com/new-page",
-                "section", ContentType.PROSE, "2026-01-01T00:00:00Z", null);
-        when(chunker.chunk(eq("# Brand new"), eq("https://example.com/new-page"), anyString()))
-                .thenReturn(List.of(chunkData));
-        when(embeddingModel.embedAll(any())).thenReturn(Response.from(List.of(Embedding.from(new float[]{0.2f}))));
-
-        IngestionService.IngestResult result = ingestionService.ingestPageIncremental(sourceId, url, "# Brand new");
-
-        assertThat(result.skipped()).isFalse();
-        assertThat(result.changed()).isTrue();
-        assertThat(result.chunksStored()).isEqualTo(1);
-        ArgumentCaptor<IngestionState> stateCaptor = ArgumentCaptor.forClass(IngestionState.class);
-        verify(ingestionStateRepository).save(stateCaptor.capture());
-        assertThat(stateCaptor.getValue().getSourceId()).isEqualTo(sourceId);
-        assertThat(stateCaptor.getValue().getPageUrl()).isEqualTo("https://example.com/new-page");
-        assertThat(stateCaptor.getValue().getContentHash()).isEqualTo(ContentHasher.sha256("# Brand new"));
-    }
-
-    @Test
-    void ingestPageIncrementalDeletesOldChunksBeforeReingesting() {
-        UUID sourceId = UUID.randomUUID();
-        String url = "https://example.com/page";
-        when(ingestionStateRepository.findBySourceIdAndPageUrl(sourceId, "https://example.com/page"))
-                .thenReturn(Optional.empty());
-        var chunkData = new DocumentChunkData("content", "https://example.com/page",
-                "section", ContentType.PROSE, "2026-01-01T00:00:00Z", null);
-        when(chunker.chunk(eq("# Content"), eq("https://example.com/page"), anyString()))
-                .thenReturn(List.of(chunkData));
+    void ingestPageCreatesTextSegmentsWithLanguageForCodeChunks() {
+        var codeChunk = new DocumentChunkData("System.out.println();", "https://docs.example.com/code",
+                "code", ContentType.CODE, "2026-01-01T00:00:00Z", "java");
+        when(chunker.chunk(anyString(), anyString(), anyString())).thenReturn(List.of(codeChunk));
         when(embeddingModel.embedAll(any())).thenReturn(Response.from(List.of(Embedding.from(new float[]{0.3f}))));
 
-        ingestionService.ingestPageIncremental(sourceId, url, "# Content");
+        ingestionService.ingestPage("```java\nSystem.out.println();\n```", "https://docs.example.com/code", "2026-01-01T00:00:00Z");
 
-        InOrder inOrder = inOrder(embeddingStore);
-        inOrder.verify(embeddingStore).removeAll(any(Filter.class));
-        inOrder.verify(embeddingStore).addAll(any(), any());
+        verify(embeddingStore).addAll(any(), segmentsCaptor.capture());
+        TextSegment segment = segmentsCaptor.getValue().getFirst();
+        assertThat(segment.metadata().getString("content_type")).isEqualTo("code");
+        assertThat(segment.metadata().getString("language")).isEqualTo("java");
     }
+
+    @Test
+    void ingestPageEmbedsBatchesOfChunks() {
+        var chunk1 = new DocumentChunkData("text A", "https://example.com/a", "a", ContentType.PROSE, "2026-01-01T00:00:00Z", null);
+        var chunk2 = new DocumentChunkData("text B", "https://example.com/a", "b", ContentType.PROSE, "2026-01-01T00:00:00Z", null);
+        when(chunker.chunk(anyString(), anyString(), anyString())).thenReturn(List.of(chunk1, chunk2));
+        when(embeddingModel.embedAll(any())).thenAnswer(invocation -> {
+            List<TextSegment> segments = invocation.getArgument(0);
+            List<Embedding> embeddings = segments.stream()
+                    .map(s -> Embedding.from(new float[]{0.1f}))
+                    .toList();
+            return Response.from(embeddings);
+        });
+
+        int result = ingestionService.ingestPage("# Page A\ntext A\n## Section B\ntext B", "https://example.com/a", "2026-01-01T00:00:00Z");
+
+        assertThat(result).isEqualTo(2);
+        verify(embeddingStore).addAll(embeddingsCaptor.capture(), segmentsCaptor.capture());
+        assertThat(embeddingsCaptor.getValue()).hasSize(2);
+        assertThat(segmentsCaptor.getValue()).hasSize(2);
+    }
+
+    // --- Delete chunks for URL ---
+
+    @Test
+    void deleteChunksForUrlDelegatesToEmbeddingStore() {
+        ingestionService.deleteChunksForUrl("https://example.com/page");
+
+        verify(embeddingStore).removeAll(any(Filter.class));
+    }
+
+    // --- Clear ingestion state ---
 
     @Test
     void clearIngestionStateDelegatesDeleteToRepository() {


### PR DESCRIPTION
## Summary

- **Scope controls**: CrawlScope record, UrlScopeFilter (glob patterns, block > allow priority), maxDepth/maxPages limits on add_source and recrawl_source
- **Incremental crawling**: SHA-256 content hashing via ContentHasher, skip unchanged pages, re-ingest changed pages, clean up deleted pages post-crawl
- **llms.txt support**: LlmsTxtParser for URL extraction, PageDiscoveryService cascade (llms-full.txt > llms.txt > sitemap > link crawl), hybrid ingestion
- **Progress tracking**: CrawlProgressTracker (thread-safe ConcurrentHashMap), real-time crawl_status MCP tool with pages crawled/skipped/errors/filtered
- **MCP tools**: Real implementations replacing stubs — add_source (7 params with scope), crawl_status (active + completed views), recrawl_source (incremental/full with one-time scope overrides)
- **Schema**: V2 Flyway migration adding scope columns to sources table
- **Tracking fixes**: Corrected ROADMAP.md, REQUIREMENTS.md, STATE.md inconsistencies across all completed phases (0-7)

Also includes Phase 5 (MCP Server) commits from prior work on this branch.

### Plans executed (5/5)
| Plan | What | Tests |
|------|------|-------|
| 07-01 | CrawlScope, UrlScopeFilter, ContentHasher (TDD) | 15 |
| 07-02 | LlmsTxtParser (TDD) | 11 |
| 07-03 | V2 migration, Source scope, CrawlProgressTracker, PageDiscoveryService cascade | 13 |
| 07-04 | CrawlService + IngestionService evolution | 24 |
| 07-05 | MCP tool real implementations | 30 |

### Requirements addressed
CRWL-03, CRWL-06, CRWL-09, CRWL-10, CRWL-11 (satisfied), CRWL-07 (deferred to manual recrawl_source), MCP-01..05

## Test plan
- [ ] `./quality.sh test` — 211 unit tests pass, 0 regressions
- [ ] `./quality.sh arch` — ArchUnit passes (no package cycles)
- [ ] `./quality.sh spotbugs` — SpotBugs clean
- [ ] Verify V2 migration applies cleanly with `./quality.sh integration`
- [ ] Verify crawl_status returns progress for active crawls
- [ ] Verify add_source with scope parameters creates source correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)